### PR TITLE
feat(EventOverlay): Adding global click listener with bubble phase

### DIFF
--- a/src/lib/EventOverlay/index.js
+++ b/src/lib/EventOverlay/index.js
@@ -101,7 +101,7 @@ export default class EventOverlay extends React.Component {
     this.handleResize = this.isVisible;
     this.handleScroll = this.isVisible;
 
-    allowClickAway && window.addEventListener('click', this.handleClick, true);
+    allowClickAway && window.addEventListener('click', this.handleClick, false);
     window.addEventListener('resize', this.handleResize, true);
     window.addEventListener('scroll', this.handleScroll, false);
     window.addEventListener('keyup', this.handleKeyUp, true);
@@ -110,7 +110,7 @@ export default class EventOverlay extends React.Component {
   };
 
   removeHandlers = () => {
-    window.removeEventListener('click', this.handleClick, true);
+    window.removeEventListener('click', this.handleClick, false);
     window.removeEventListener('resize', this.handleResize, true);
     window.removeEventListener('scroll', this.handleScroll, true);
     window.removeEventListener('keyup', this.handleKeyUp, true);


### PR DESCRIPTION
Catching onClick events on window in bubble phase, to support closeOnClick prop.
The only disadvantage(edge case) of doing this is if some elements in the page capture events and stopPropagation then the popover might not close.

The only other alternative is to call the closeCallback within an setTimeout(to run in diff event loop), which looks clumsy.
@pauljeter @bfbiggs 