### PR TITLE
feat(EventOverlay): Handling closeOnClick in bubble phase

### DIFF
--- a/src/lib/EventOverlay/index.js
+++ b/src/lib/EventOverlay/index.js
@@ -97,11 +97,12 @@ export default class EventOverlay extends React.Component {
   };
 
   addHandlers = () => {
-    const { allowClickAway } = this.props;
+    const { allowClickAway, closeOnClick } = this.props;
     this.handleResize = this.isVisible;
     this.handleScroll = this.isVisible;
 
-    allowClickAway && window.addEventListener('click', this.handleClick, false);
+    allowClickAway && window.addEventListener('click', this.handleAllowClickAway, true);
+    closeOnClick && window.addEventListener('click', this.handleCloseOnClick, false);
     window.addEventListener('resize', this.handleResize, true);
     window.addEventListener('scroll', this.handleScroll, false);
     window.addEventListener('keyup', this.handleKeyUp, true);
@@ -110,10 +111,23 @@ export default class EventOverlay extends React.Component {
   };
 
   removeHandlers = () => {
-    window.removeEventListener('click', this.handleClick, false);
+    window.removeEventListener('click', this.handleAllowClickAway, true);
+    window.removeEventListener('click', this.handleCloseOnClick, false);
+
     window.removeEventListener('resize', this.handleResize, true);
     window.removeEventListener('scroll', this.handleScroll, false);
     window.removeEventListener('keyup', this.handleKeyUp, true);
+  };
+
+  handleCloseOnClick = e => {
+    if (!this.props.isOpen) return;
+    const { closeOnClick } = this.props;
+    return (
+        closeOnClick
+        && this.container
+        && ReactDOM.findDOMNode(this.container).contains(e.target)
+        && this.handleClickAway(e)
+    );
   };
 
   handleKeyUp = e => {
@@ -129,17 +143,13 @@ export default class EventOverlay extends React.Component {
     );
   };
 
-  handleClick = e => {
+  handleAllowClickAway = e => {
     if (!this.props.isOpen) return;
     const anchorNode = ReactDOM.findDOMNode(this.props.anchorNode);
     return (
       this.container
         && !ReactDOM.findDOMNode(anchorNode).contains(e.target)
-        && (
-          this.props.closeOnClick
-          ||
-          !ReactDOM.findDOMNode(this.container).contains(e.target)
-        )
+        && !ReactDOM.findDOMNode(this.container).contains(e.target)
         && this.handleClickAway(e)
     );
   };

--- a/src/lib/EventOverlay/index.spec.js
+++ b/src/lib/EventOverlay/index.spec.js
@@ -127,7 +127,7 @@ describe('tests for <EventOverlay />', () => {
     expect(container.find('.cui-event-overlay--top').length).toEqual(1);
 
     // making a click outside
-    container.childAt(0).childAt(0).childAt(1).instance().handleClick({});
+    container.childAt(0).childAt(0).childAt(1).instance().handleAllowClickAway({});
     jest.runAllTimers();
     container.update();
     expect(container.find('.cui-event-overlay--top').length).toEqual(0);
@@ -158,7 +158,7 @@ describe('tests for <EventOverlay />', () => {
     expect(container.find('.cui-event-overlay--top').length).toEqual(1);
 
     // when tabbed out of the Overlay
-    container.childAt(0).childAt(0).childAt(1).instance().handleClick({});
+    container.childAt(0).childAt(0).childAt(1).instance().handleAllowClickAway({});
     expect(container.find('.cui-event-overlay--top').length).toEqual(1);
   });
 });


### PR DESCRIPTION
Handling closeOnClick on event bubble phase (so that onClick callbacks on elements can be called) and allowClickAway is handled on bubble capture phase.

This is in reference to https://github.com/collab-ui/collab-ui-react/pull/41, to handle that corner scenario. 
There no neat way to test these listeners on window with enzyme(.simulate events are not caught on 
 window).

@pauljeter @bfbiggs 