### PR TITLE
fix(EditableTextfield): pass entire event object to parent component

### DIFF
--- a/src/lib/EditableTextfield/index.js
+++ b/src/lib/EditableTextfield/index.js
@@ -23,9 +23,9 @@ class EditableTextfield extends React.PureComponent {
     }
   }
 
-  handleDoneEditing = value => {
+  handleDoneEditing = e => {
     const { handleDoneEditing } = this.props;
-
+    let value = (e.target && e.target.value) ? value = e.target.value : value = e;
     this.setState({
       isEditing: false,
       inputText: value,
@@ -69,7 +69,7 @@ class EditableTextfield extends React.PureComponent {
         isEditing: false,
       });
     } else if (e.keyCode === 13) {
-      this.handleDoneEditing(e.target.value);
+      this.handleDoneEditing(e);
     }
   }
 


### PR DESCRIPTION
Passes entire event object back to parent component for handleDoneEditing. This is so we can detect the "Enter" keycode and bring other components to focus in that case.