### PR TITLE
fix(Popover): clear timeout on mouse leave

### DIFF
--- a/src/lib/Popover/index.js
+++ b/src/lib/Popover/index.js
@@ -100,6 +100,11 @@ class Popover extends React.Component {
       return false;
     }
 
+    if (this.showTimerId) {
+      clearTimeout(this.showTimerId);
+      this.showTimerId = null;
+    }
+
     children.props.onMouseLeave && children.props.onMouseLeave(e);
     return !this.hideTimerId && this.state.isOpen && this.delayCheckHover(e);
   };
@@ -329,7 +334,6 @@ export default Popover;
         <Popover content={content} delay={500} direction={'top-center'}>
           <Button children='Hover with Delay' ariaLabel='Hover with Delay' />
         </Popover>
-
       </div>
     </div>
   );


### PR DESCRIPTION
Fixed:
![2018-09-06 11 45 13](https://user-images.githubusercontent.com/41644838/45178401-6fae3c80-b1ca-11e8-9fc4-e77eb942cc26.gif)
Old:
![2018-08-29 09 57 07](https://user-images.githubusercontent.com/41644838/45176523-1bed2480-b1c5-11e8-97db-a5c113135a89.gif)
 Fix this issue