### PR TITLE
fix(Button): prevent active styles if disabled

### DIFF
--- a/src/lib/Button/index.js
+++ b/src/lib/Button/index.js
@@ -146,7 +146,7 @@ class Button extends React.Component {
           `${(expand && ` cui-button--expand`) || ''}` +
           `${(color && ` cui-button--${getColor()}`) || ''}` +
           `${(removeStyle && ' cui-button--none') || ''}` +
-          `${(active && ` active`) || ''}` +
+          `${(active && !disabled && ` active`) || ''}` +
           `${(className && ` ${className}`) || ''}`,
         onClick: e => this.handleClick(e, onClick),
         onKeyDown: this.handleKeyDown,


### PR DESCRIPTION
resolves #80 

#### Issue was reproduced by:
The `Button` Component has `active` & `disabled` properties as true. The button UX shows that it is an enabled button, but in fact is disabled and is unresponsive.