### PR TITLE
Doc(*): Edit React library with prop comments to conform to new prop-parser

### DIFF
--- a/src/lib/Accordion/__snapshots__/index.spec.js.snap
+++ b/src/lib/Accordion/__snapshots__/index.spec.js.snap
@@ -4,8 +4,8 @@ exports[`tests for <Accordion /> should match SnapShot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <AccordionMenu
-    classname=""
-    initalActive={Array []}
+    className=""
+    initialActive={Array []}
     multipleVisible={false}
     onSelect={null}
     showSeparator={false}

--- a/src/lib/Accordion/index.js
+++ b/src/lib/Accordion/index.js
@@ -204,11 +204,17 @@ class AccordionMenu extends React.Component {
 }
 
 AccordionMenu.propTypes = {
+  /** @prop Children nodes to render inside Accordion | null */
   children: PropTypes.node,
+  /** @prop Set to allow expansion of multiple AccordionGroups | false */
   multipleVisible: PropTypes.bool,
+  /** @prop Handler to be called when the user selects Accordion | null */
   onSelect: PropTypes.func,
+  /** @prop An array of indexes that are preselected | [] */
   initialActive: PropTypes.array,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Optional underline under Accordion menu item | false  */
   showSeparator: PropTypes.bool,
 };
 
@@ -216,8 +222,8 @@ AccordionMenu.defaultProps = {
   children: null,
   multipleVisible: false,
   onSelect: null,
-  initalActive: [],
-  classname: '',
+  initialActive: [],
+  className: '',
   showSeparator: false,
 };
 

--- a/src/lib/AccordionContent/index.js
+++ b/src/lib/AccordionContent/index.js
@@ -24,7 +24,9 @@ const AccordionContent = props => {
 AccordionContent.displayName = 'AccordionContent';
 
 AccordionContent.propTypes = {
+  /** @prop Children nodes to render inside AccordionContent | null */
   children: PropTypes.node,
+  /** @prop Optional css class string | ''  */
   className: PropTypes.string,
 };
 

--- a/src/lib/AccordionGroup/index.js
+++ b/src/lib/AccordionGroup/index.js
@@ -68,13 +68,21 @@ class AccordionGroup extends React.Component {
 }
 
 AccordionGroup.propTypes = {
+  /** @prop Children nodes to render inside Accordion | null  */
   children: PropTypes.node,
+  /** @prop Set accordionGroup to be expanded | false  */
   isExpanded: PropTypes.bool,
-  disabled: PropTypes.bool,
+  /** @prop Handler to be called when the user taps the AccordionGroup | null */
   onClick: PropTypes.func,
+  /** @prop Handler to be called when the user presses a key | null */
   onKeyDown: PropTypes.func,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Set the attribute disabled to the accordionGroup | false */
+  disabled: PropTypes.bool,
+  /** @prop Specifies if AccordionGroup show automatically get focus when page loads | false  */
   focus: PropTypes.bool,
+  /** @prop Optional underline under Accordion menu item | false */
   showSeparator: PropTypes.bool,
 };
 

--- a/src/lib/AccordionHeader/index.js
+++ b/src/lib/AccordionHeader/index.js
@@ -53,11 +53,17 @@ class AccordionHeader extends React.Component {
 }
 
 AccordionHeader.propTypes = {
+  /** @prop Children nodes to render inside AccordionHeader | null  */
   children: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Set the attribute disabled to the AccordionHeader | false */
   disabled: PropTypes.bool,
+  /** @prop Specifies if AccordionHeader automatically gets focus when page loads | false  */
   focus: PropTypes.bool,
+  /** @prop Optional underline under Accordion menu item | false */
   showSeparator: PropTypes.bool,
+  /** @prop Set the height of the AccordionHeader to either the default or 56px | '' */
   height: PropTypes.oneOf(['', 56]),
 };
 

--- a/src/lib/ActivityButton/index.js
+++ b/src/lib/ActivityButton/index.js
@@ -46,29 +46,17 @@ const ActivityButton = props => {
 ActivityButton.displayName = 'ActivityButton';
 
 ActivityButton.propTypes = {
-  /**
-   * Text to display for blindness accessibility features
-   */
+  /** @prop Text to display for blindness accessibility features | '' */
   ariaLabel: PropTypes.string,
-  /**
-   * optional css class string
-   */
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
-  /**
-   * Sets the attribute disabled to the button
-   */
+  /** @prop Sets the attribute disabled to the button | false */
   disabled: PropTypes.bool,
-  /**
-   * Sets the large attribute to the button
-   */
+  /** @prop Sets the large attribute to the button | false */
   large: PropTypes.bool,
-  /**
-   * Handler to be called when the user taps the button
-   */
+  /** @prop Handler to be called when the user taps the button | null */
   onClick: PropTypes.func,
-  /**
-   *  activity prop type
-   */
+  /** @prop Sets the button's activity type */
   type: PropTypes.oneOfType([
     PropTypes.oneOf(['chat', 'camera', 'meetings', 'whiteboard', 'files', 'share-screen', 'tasks']),
     PropTypes.shape({

--- a/src/lib/Alert/index.js
+++ b/src/lib/Alert/index.js
@@ -56,30 +56,17 @@ Alert.defaultProps = {
 };
 
 Alert.propTypes = {
-  /**
-   *  To show/hide Close CTA of the Alert.
-   */
+  /** @prop To show/hide Close button of the Alert | false */
   closable: PropTypes.bool,
-  /**
-   * optional Alert Message
-   */
+  /** @prop Optional Alert message | '' */
   message: PropTypes.string,
-  /**
-   * callback function invoked on close of the Alert. Alert can be closed on click of cross button or esc key.
-   * onHide is mandatory props, if not passed Alert can not be closed.
-   */
+  /** @prop Mandatory handler invoked when the user presses on the Alert's close button or hit's the esc key | null */
   onHide: PropTypes.func,
-  /**
-   * show/hide Alert.
-   */
+  /** @prop Set Alert visibility */
   show: PropTypes.bool.isRequired,
-  /**
-   * optional Alert Title
-   */
+  /** @prop Optional Alert title | '' */
   title: PropTypes.string,
-  /**
-   * size of the Alert.
-   */
+  /** @prop Sets the type of the Alert | 'info' */
   type: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
 };
 

--- a/src/lib/AlertBanner/index.js
+++ b/src/lib/AlertBanner/index.js
@@ -50,16 +50,15 @@ AlertBanner.defaultProps = {
 };
 
 AlertBanner.propTypes = {
-  // show/hide modal.
+  /** @prop Set AlertBanner visibility */
   show: PropTypes.bool.isRequired,
-  // Children components
+  /** @prop Children nodes to render inside AccordionHeader | null  */
   children: PropTypes.node,
-  // size of the modal.
+  /** @prop Sets the AlertBanner type | 'info' */
   type: PropTypes.oneOf(['info', 'warning', 'error']),
-  // Callback function invoked on close of the modal. modal can be closed on click of cross button or esc key.
-  // onHide is mandatory props, if not passed modal can not be closed.
+  /** @prop Mandatory handler invoked when the user presses on the AlertBanner's close button or hit's the esc key | () => {} */
   onHide: PropTypes.func,
-  // To show/hide Close CTA of the modal.
+  /** @prop Sets the visibility of AlertBanner's close button | false */
   closable: PropTypes.bool,
 };
 

--- a/src/lib/AlertCall/index.js
+++ b/src/lib/AlertCall/index.js
@@ -120,66 +120,38 @@ AlertCall.defaultProps = {
 };
 
 AlertCall.propTypes = {
-  /**
-   * optional avatar prop
-   */
+  /** @prop Optional avatar prop | null */
   avatar: PropTypes.node,
-  /**
-   * required caller object
-   */
+  /** @prop Required caller object */
   caller: PropTypes.shape({
     title: PropTypes.string.isRequired,
     alt: PropTypes.string,
     src: PropTypes.string,
     type: PropTypes.oneOf(['', 'number', 'device']),
   }).isRequired,
-  /**
-   * optional default selected device
-   */
+  /** @prop Optional default selected device | 0 */
   defaultSelectedDevice: PropTypes.number,
-  /**
-   * optional header string for device selection list
-   */
+  /** @prop Optional header string for device selection list | "Device selection" */
   deviceListHeader: PropTypes.string,
-  /**
-   * optional list of devices to answer call with.
-   */
+  /** @prop Optional list of devices to answer call with | [] */
   devices: PropTypes.array,
-  /**
-   * callback function invoked when the video button is clicked.
-   */
+  /** @prop Callback function invoked when the video button is clicked | null */
   onAnswerVideo: PropTypes.func,
-  /**
-   * callback function invoked when the handset button is clicked.
-   */
+  /** @prop Callback function invoked when the handset button is clicked | null */
   onAnswerVoice: PropTypes.func,
-  /**
-   * optional callback function when device is selected
-   */
+  /** @prop Optional callback function when device is selected | null */
   onDeviceSelect: PropTypes.func,
-  /**
-   * callback function invoked when the reject button is clicked.
-   */
+  /** @prop Callback function invoked when the reject button is clicked | null */
   onReject: PropTypes.func,
-  /**
-   * optional aria-label reject
-   */
+  /** @prop Optional aria-label reject message | 'reject call' */
   rejectAriaLabel: PropTypes.string,
-  /**
-   * required show/hide AlertCall.
-   */
+  /** @prop Required AlertCall visitibility setting */
   show: PropTypes.bool.isRequired,
-  /**
-   * optional title of AlertCall
-   */
+  /** @prop Optional title of AlertCall | '' */
   title: PropTypes.string,
-    /**
-   * optional aria-label video
-   */
+  /** @prop Optional aria-label video | 'answer call with voice and video' */
   videoAriaLabel: PropTypes.string,
-  /**
-   * optional aria-label voice
-   */
+  /** @prop Optional aria-label voice | 'answer call with voice only' */
   voiceAriaLabel: PropTypes.string,
 };
 

--- a/src/lib/AlertCallContainer/index.js
+++ b/src/lib/AlertCallContainer/index.js
@@ -16,9 +16,7 @@ AlertCallContainer.defaultProps = {
 };
 
 AlertCallContainer.propTypes = {
-  /**
-   * Array of AlertCall components
-   */
+  /** @prop Array of AlertCall components | [] */
   alertList: PropTypes.arrayOf(PropTypes.node)
 };
 

--- a/src/lib/AlertContainer/index.js
+++ b/src/lib/AlertContainer/index.js
@@ -111,9 +111,9 @@ AlertContainer.defaultProps = {
 };
 
 AlertContainer.propTypes = {
-  /** Display new alert messages at the top or bottom of the queue */
+  /** @prop Display newest alert messages first | true */
   orderNewest: PropTypes.bool,
-  /** Position alert will display */
+  /** @prop Define alert's position with css class name: 'bottom-right' */
   position: PropTypes.oneOf(['top-left', 'top-center', 'top-right', 'bottom-left', 'bottom-center', 'bottom-right'])
 };
 

--- a/src/lib/AlertMeeting/index.js
+++ b/src/lib/AlertMeeting/index.js
@@ -147,14 +147,9 @@ AlertMeeting.defaultProps = {
 };
 
 AlertMeeting.propTypes = {
-  /**
-   * optional avatar prop
-   */
+  /** @prop Optional avatar prop | null */
   avatar: PropTypes.node,
-  /**
-   * optional attendee array.  If more than one attendee, a Composite Avatar will be composed.
-   * Only use first two attendees in array will be used, the others will be ignored.
-   */
+  /** @prop Optional attendee array. If more than one attendee, a Composite Avatar with only the first 2 attendees is created. | null */
   attendees: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string.isRequired,
@@ -162,42 +157,23 @@ AlertMeeting.propTypes = {
       src: PropTypes.string,
     })
   ),
-    /**
-   * optional aria label for close buton
-   */
+    /** @prop Optional aria label for the close button | 'close' */
   closeAriaLabel: PropTypes.string,
-  /**
-   * optional callback function invoked on click of alert
-   */
+  /** @prop Optional callback function invoked on click of alert | null */
   onClick: PropTypes.func,
-  /**
-   * callback function invoked on close of the Alert. Alert can be closed on click of cross button or esc key.
-   * onHide is mandatory props, if not passed Alert can not be closed.
-   */
+  /** @prop Mandatory handler invoked when the user presses on the Alert's close button or hit's the esc key | null */
   onHide: PropTypes.func,
-  /**
-   * optional callback function invoked when the snooze button is clicked.
-   */
+  /** @prop Optional callback function invoked when the snooze button is clicked | null */
   onSnooze: PropTypes.func,
-  /**
-   * optional AlertMeeting Message
-   */
+  /** @prop Optional AlertMeeting Message | '' */
   message: PropTypes.string,
-  /**
-   * optional aria label for snooze buton
-   */
+  /** @prop Optional aria label for snooze buton | 'snooze' */
   remindAriaLabel: PropTypes.string,
-  /**
-   * show/hide AlertMeeting.
-   */
+  /** @prop Set AlertMeeting visibility */
   show: PropTypes.bool.isRequired,
-  /**
-   * optional AlertMeeting Status
-   */
+  /** @prop Optional AlertMeeting status | '' */
   status: PropTypes.string,
-  /**
-   * optional AlertMeeting Title
-   */
+  /** @prop Optional AlertMeeting title | '' */
   title: PropTypes.string,
 };
 

--- a/src/lib/AlertMeetingContainer/index.js
+++ b/src/lib/AlertMeetingContainer/index.js
@@ -16,9 +16,7 @@ AlertMeetingContainer.defaultProps = {
 };
 
 AlertMeetingContainer.propTypes = {
-  /**
-   * Array of AlertMeeting components
-   */
+  /** @prop Array of AlertMeeting components | [] */
   alertList: PropTypes.arrayOf(PropTypes.node)
 };
 

--- a/src/lib/Avatar/index.js
+++ b/src/lib/Avatar/index.js
@@ -186,22 +186,39 @@ class Avatar extends React.Component {
 }
 
 Avatar.propTypes = {
+  /** @prop Image alt tag | '' */
   alt: PropTypes.string,
+  /** @prop Set Avatar background color | '' */
   backgroundColor: PropTypes.string,
+  /** @prop Optional css class string for button | '' */
   buttonClassName: PropTypes.string,
+  /** @prop Optional css class string for Avatar component | null */
   className: PropTypes.string,
+  /** @prop Set Avatar text color | '' */
   color: PropTypes.string,
+  /** @prop Set existance of a failureBadge on the Avatar | false */
   failureBadge: PropTypes.bool,
+  /** @prop Set existance of a notification on the Avatar | false */
   hasNotification: PropTypes.bool,
+  /** @prop Set the visibility of Avatar's default tooltip | false */
   hideDefaultTooltip: PropTypes.bool,
+  /** @prop Optional icon component for the Avatar | null */
   icon: PropTypes.element,
+  /** @prop Set if Avatar's content is decrypting | false */
   isDecrypting: PropTypes.bool,
+  /** @prop Set existance of Avatar's Overview | false */
   isOverview: PropTypes.bool,
+  /** @prop Handler to be called when the user taps the Avatar | null */
   onClick: PropTypes.func,
+  /** @prop Set the size of the Avatar from one of the preconfigured options | 'medium' */
   size: PropTypes.oneOf(['xsmall', 'small', 'medium', 'large', 'xlarge', 18, 24, 28, 36, 40, 44, 52, 56, 72, 80, 84]),
+  /** @prop Optional image source for the Avatar | null */
   src: PropTypes.string,
+  /** @prop Optional Avatar color theme | null */
   theme: PropTypes.string,
+  /** @prop set Avatar title / user's name | null */
   title: PropTypes.string,
+  /** @prop optional Avatar type | '' */
   type: PropTypes.oneOf(['', 'active', 'inactive', 'dnd', 'ooo', 'group', 'typing', 'bot', 'self']),
 };
 

--- a/src/lib/Badge/index.js
+++ b/src/lib/Badge/index.js
@@ -28,22 +28,14 @@ const Badge = props => {
 Badge.displayName = 'Badge';
 
 Badge.propTypes = {
-  /**
-   * optional css class string
-   */
-  className: PropTypes.string,
-  /**
-   * optional type prop type
-   */
-  color: PropTypes.string,
-  /**
-   * optional rounded prop type
-   */
-  rounded: PropTypes.bool,
-  /**
-   * optional single element child
-   */
+  /** @prop Children nodes to render inside Accordion | null */
   children: PropTypes.element,
+  /** @prop Optional css class string | '' */
+  className: PropTypes.string,
+  /** @prop Optional color prop type | null */
+  color: PropTypes.string,
+  /** @prop Optional rounded corners for the Badge | false */
+  rounded: PropTypes.bool,
 };
 
 Badge.defaultProps = {

--- a/src/lib/Breadcrumbs/index.js
+++ b/src/lib/Breadcrumbs/index.js
@@ -16,7 +16,9 @@ class Breadcrumbs extends React.PureComponent {
   };
 
   static defaultProps = {
+    /** @prop Children nodes to render inside Breadcrumbs | null */
     children: null,
+    /** @prop Optional css class string | '' */
     className: ''
   };
 

--- a/src/lib/Breadcrumbs/index.js
+++ b/src/lib/Breadcrumbs/index.js
@@ -8,19 +8,6 @@ import PropTypes from 'prop-types';
  */
 
 class Breadcrumbs extends React.PureComponent {
-  static displayName = 'Breadcrumbs';
-
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string
-  };
-
-  static defaultProps = {
-    /** @prop Children nodes to render inside Breadcrumbs | null */
-    children: null,
-    /** @prop Optional css class string | '' */
-    className: ''
-  };
 
   render() {
     const { className, children } = this.props;
@@ -36,6 +23,20 @@ class Breadcrumbs extends React.PureComponent {
     return <ul className={'cui-breadcrumbs' + ` ${className}`}>{items}</ul>;
   }
 }
+
+Breadcrumbs.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string
+};
+
+Breadcrumbs.defaultProps = {
+  /** @prop Children nodes to render inside Breadcrumbs | null */
+  children: null,
+  /** @prop Optional css class string | '' */
+  className: ''
+};
+
+Breadcrumbs.displayName = 'Breadcrumbs';
 
 export default Breadcrumbs;
 

--- a/src/lib/Button/index.js
+++ b/src/lib/Button/index.js
@@ -191,47 +191,47 @@ Button.contextTypes = {
 };
 
 Button.propTypes = {
-  /** optional active prop typ */
+  /** @prop Sets active css styling | false */
   active: PropTypes.bool,
-  /** Text to display for blindness accessibility features */
+  /** @prop Text to display for blindness accessibility features | '' */
   ariaLabel: PropTypes.string,
-  /** ID to reference for blindness accessibility feature */
+  /** @prop ID to reference for blindness accessibility feature | '' */
   ariaLabelledBy: PropTypes.string,
-  /** Children Nodes to Render inside button */
+  /** @prop Children Nodes to Render inside Button | null */
   children: PropTypes.node.isRequired,
-  /** optional circle prop type */
+  /** @prop Sets circle css styling | false */
   circle: PropTypes.bool,
-  /** optional css class string */
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
-  /** optional color prop type */
+  /** @prop Sets optional Button color | '' */
   color: PropTypes.string,
-  /** optional containerLarge prop type */
+  /** @prop Sets containerLarge css styling | false */
   containerLarge: PropTypes.bool,
-  /** Sets the attribute disabled to the button */
+  /** @prop Sets the attribute disabled to Button | false */
   disabled: PropTypes.bool,
-  /** Sets the attribute expanded to the button */
+  /** @prop Sets expand css styling to widen the Button | false */
   expand: PropTypes.bool,
-  /** Href prop changes element to anchor element */
+  /** @prop Href prop changes element to anchor element | '' */
   href: PropTypes.string,
-  /** This index used to control focus of Button within a ButtonGroup */
+  /** @prop This index is used to control focus of Button within a ButtonGroup | null */
   index: PropTypes.number,
-  /** Text to display inside the button */
+  /** @prop Text to display inside the button | '' */
   label: PropTypes.string,
-  /** optional large prop type */
+  /** @prop Depreciated large css styling, use size instead | false */
   large: PropTypes.bool,
-  /** Activates the loading animation and sets the button to disabled */
+  /** @prop Activates the loading animation and sets the button to disabled | false */
   loading: PropTypes.bool,
-  /** Handler to be called when the user taps the button */
+  /** @prop Handler to be called when the user taps the button | null */
   onClick: PropTypes.func,
-  /** optional prop to remove style */
+  /** @prop Optional prop to remove Button's default style | false */
   removeStyle: PropTypes.bool,
-  /** Size className */
+  /** @prop Optional string or number size prop | 36 */
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /** Additional styling applied to the button */
+  /** @prop Additional css styling applied to the button | {} */
   style: PropTypes.object,
-  /** optional tag prop type */
+  /** @prop Optional tag to define type of element | 'button' */
   tag: PropTypes.oneOf(['button', 'input', 'a']),
-  /** optional type prop type */
+  /** @prop Optional html type | 'button' */
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
 };
 

--- a/src/lib/ButtonGroup/index.js
+++ b/src/lib/ButtonGroup/index.js
@@ -224,16 +224,27 @@ class ButtonGroup extends React.Component {
 }
 
 ButtonGroup.propTypes = {
+  /** @prop Sets initial active Button by index | null */
   activeIndex: PropTypes.number,
+  /** @prop Text to display for blindness accessibility features | '' */
   ariaLabel: PropTypes.string,
+  /** @prop Children nodes to render inside ButtonGroup | null */
   children: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Set focus to ButtonGroup when page is loaded | false */
   focusOnLoad: PropTypes.bool,
+  /** @prop Highlights the selected button within group | true */
   highlightSelected: PropTypes.bool,
+  /** @prop Optional text-justified css styling | true */
   justified: PropTypes.bool,
+  /** @prop Handler to be called when the user selects ButtonGroup | null */
   onSelect: PropTypes.func,
+  /** @prop Sets width of a pill Button | '60px' */
   pillWidth: PropTypes.string,
+  /** @prop Optional Button color theme for ButtonGroup | '' */
   theme: PropTypes.oneOf(['', 'dark']),
+  /** @prop Optional Button type for ButtonGroup | '' */
   type: PropTypes.oneOf(['', 'pill']),
 };
 
@@ -245,8 +256,8 @@ ButtonGroup.defaultProps = {
   focusOnLoad: false,
   highlightSelected: true,
   justified: true,
-  pillWidth: '60px',
   onSelect: null,
+  pillWidth: '60px',
   theme: '',
   type:'',
 };

--- a/src/lib/CallControl/index.js
+++ b/src/lib/CallControl/index.js
@@ -44,37 +44,21 @@ class CallControl extends React.PureComponent {
 }
 
 CallControl.propTypes = {
-  /**
-   * Sets the active state for the button
-   */
+  /** @prop Sets active css styling | false */
   active: PropTypes.bool,
-  /**
-   * Text to display for blindness accessibility features
-   */
+  /** @prop Text to display for blindness accessibility features | '' */
   ariaLabel: PropTypes.string,
-  /**
-   * optional css class string
-   */
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
-  /**
-   * Sets the attribute disabled to the button
-   */
+  /** @prop Sets the attribute disabled to the CallControl button | false */
   disabled: PropTypes.bool,
-  /**
-   * Optional icon size prop
-   */
+  /** @prop Optional numeric icon size prop | 24 */
   iconSize: PropTypes.number,
-  /**
-   * Handler to be called when the user taps the button
-   */
+  /** @prop Handler to be called when the user taps the CallControl button | null */
   onClick: PropTypes.func,
-  /**
-   * Optional size prop for circular button
-   */
+  /** @prop Optional numeric size prop for CallControl button | 56 */
   size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  /**
-   * optional call control prop type
-   */
+  /** @prop Optional predefined CallControl prop type | '' */
   type: PropTypes.oneOf(['microphone-muted', 'cancel', 'camera-muted', 'share-screen', 'speaker']),
 };
 

--- a/src/lib/Card/index.js
+++ b/src/lib/Card/index.js
@@ -141,10 +141,12 @@ class Card extends React.Component {
 
 Card.defaultProps = {
   header: '',
-  label: '',
+  headerAlign: null,
+  headerBackground: '',
   headerBorder: false,
   headerColor: '',
-  headerBackground: '',
+  headerLabel: '',
+  label: '',
   size: '',
   sizeNum: 0,
   nav: false,
@@ -170,10 +172,6 @@ Card.propTypes = {
   //  * show/hide modal.
   //  */
   // show: PropTypes.bool.isRequired,
-  /**
-   * size of the card.
-   */
-  size: PropTypes.oneOf(['small', 'medium', 'large', 'full']),
   // /**
   //  * callback function invoked on close of the modal. modal can be closed on click of cross button or esc key.
   //  * onHide is mandatory props, if not passed modal can not be closed.
@@ -188,36 +186,24 @@ Card.propTypes = {
   //  *  if backdrop is false then modal will become normal popup without backdrop and user can perform any action in parent screen.
   //  */
   // backdrop: PropTypes.bool,
-  /**
-   * Number to define size
-   *
-   */
-  sizeNum: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-  /**
-   *  Is Card used for nav?
-   *
-   */
-  nav: PropTypes.bool,
-  /**
-   * card label
-   */
-  label: PropTypes.string,
-  /**
-   * show/hide header border
-   */
-  headerBorder: PropTypes.bool,
-  /**
-   * header will appear with string
-   */
-  headerLabel: PropTypes.string,
-  /**
-   * header background will appear with string
-   */
-  headerColor: PropTypes.string,
-  /**
-   * alignment of header
-   */
+
+  /** @prop Alignment of header | null */
   headerAlign: PropTypes.oneOf(['left', 'center']),
+  /** @prop Set visitibility of the header's border | false */
+  headerBorder: PropTypes.bool,
+  /** @prop Set header color | '' */
+  headerColor: PropTypes.string,
+  /** @prop Set header's Text | '' */
+  headerLabel: PropTypes.string,
+  /** @prop Set Card Text | '' */
+  label: PropTypes.string,
+  /** @prop Set size of the card from list of prefined strings | '' */
+  size: PropTypes.oneOf(['small', 'medium', 'large', 'full']),
+  /** @prop Set number to define size | 0 */
+  sizeNum: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+    /** @prop Sets of Card is used for nav | false */
+  nav: PropTypes.bool,
+
 };
 
 export default Card;

--- a/src/lib/Checkbox/index.js
+++ b/src/lib/Checkbox/index.js
@@ -63,73 +63,47 @@ const Checkbox = props => {
 };
 
 Checkbox.propTypes = {
-  /**
-   * optional nextLevel prop type
-   */
-  nestedLevel: PropTypes.number,
-  /**
-   * optional className prop type
-   */
-  className: PropTypes.string,
-  /**
-   * optional indeterminate prop type
-   */
-  indeterminate: PropTypes.bool,
-  /**
-   * optional disabled prop type
-   */
-  disabled: PropTypes.bool,
-  /**
-   * optional required prop type
-   */
-  required: PropTypes.bool,
-  /**
-   * optional checked prop type
-   */
+  /** @prop Sets Checkbox status as checked | false */
   checked: PropTypes.bool,
-  /**
-   * optional name prop type
-   */
-  name: PropTypes.string,
-  /**
-   * optional label prop type
-   */
-  label: PropTypes.string.isRequired,
-  /**
-   * optional value prop type
-   */
-  value: PropTypes.string,
-  /**
-   * optional ref prop type
-   */
-  inputRef: PropTypes.func,
-  /**
-   * Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing.
-   */
-  htmlId: PropTypes.string.isRequired,
-  /**
-   * optional onChange prop type
-   */
-  onChange: PropTypes.func,
-  /**
-   * Child component to display next to the input
-   */
+  /** @prop Child component to display next to the input | null */
   children: PropTypes.node,
+  /** @prop Optional css class string | ''  */
+  className: PropTypes.string,
+  /** @prop Sets the attribute disabled to the Checkbox | false */
+  disabled: PropTypes.bool,
+  /** @prop Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing */
+  htmlId: PropTypes.string.isRequired,
+  /** @prop Optional indeterminate capabilities of checkbox | false */
+  indeterminate: PropTypes.bool,
+  /** @prop optional ref attribute for Checkbox input element | null */
+  inputRef: PropTypes.func,
+  /** @prop Required label string for Checkbox */
+  label: PropTypes.string.isRequired,
+  /** @prop Sets the attribute name to the Checkbox input element | '' */
+  name: PropTypes.string,
+  /** @prop Set the level of nested checkboxes | 0 */
+  nestedLevel: PropTypes.number,
+  /** @prop Optional onChange handler invoked when user makes a change within the Checkbox input element | null */
+  onChange: PropTypes.func,
+  /** @prop Optional required setting for Checkbox input | false */
+  required: PropTypes.bool,
+  /** @prop sets value of the Checkbox input element | '' */
+  value: PropTypes.string,
 };
 
 Checkbox.defaultProps = {
-  nestedLevel: 0,
-  className: '',
-  indeterminate: false,
-  disabled: false,
-  required: false,
   autoFocus: false,
   checked: false,
-  name: '',
-  value: '',
-  label: '',
+  className: '',
+  disabled: false,
+  indeterminate: false,
   inputRef: null,
+  label: '',
+  name: '',
+  nestedLevel: 0,
   onChange: null,
+  required: false,
+  value: '',
 };
 
 Checkbox.displayName = 'Checkbox';

--- a/src/lib/CheckboxGroup/index.js
+++ b/src/lib/CheckboxGroup/index.js
@@ -60,27 +60,17 @@ class CheckboxGroup extends React.Component {
 }
 
 CheckboxGroup.propTypes = {
-  /**
-   * optional children prop type
-   */
+  /** @prop Children nodes to render inside Accordion | null */
   children: PropTypes.node,
-  /**
-   * Callback fired when a button is pressed, `onChange` will be called with the value or
-   * array of active values
-   *
+  /** @prop Callback fired with the value or array of active values when the user presses a button | null
    * @controllable values
-   */
+  */
   onChange: PropTypes.func,
-  /**
-   * An array of values, of the active (pressed) buttons
-   *
+  /** @prop An array of values, of the active (pressed) buttons | () => {}
    * @controllable onChange
    */
   values: PropTypes.array,
-  /**
-   * An HTML `<input>` name for each child button.
-   *
-   */
+  /** @prop An HTML `<input>` name for each child button | '' */
   name: PropTypes.string,
 };
 

--- a/src/lib/Chip/index.js
+++ b/src/lib/Chip/index.js
@@ -77,8 +77,11 @@ const Chip = ({
 };
 
 Chip.propTypes = {
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Sets file for anchor element to download | '' */
   fileDownloadLink: PropTypes.string,
+  /** @prop Sets type of file | null */
   fileType: PropTypes.oneOf([
     'audio',
     'graph',
@@ -91,10 +94,15 @@ Chip.propTypes = {
     'video',
     'zip',
   ]),
+  /** @prop Node that becomes the content on the left of Chip | null */
   leftContent: PropTypes.node,
+  /** @prop NOde that becomes the content on the right of Chip | null */
   rightContent: PropTypes.node,
+  /** @prop Text of the Chip's subtitle | '' */
   subTitle: PropTypes.string,
+  /** @prop Text of the Chip's title | null */
   title: PropTypes.string,
+  /** @prop Sets the type of icon for the Chip | null */
   type: PropTypes.oneOf(['file', 'recording', 'unauthorized']),
 };
 

--- a/src/lib/CloseIcon/index.js
+++ b/src/lib/CloseIcon/index.js
@@ -27,14 +27,10 @@ CloseIcon.defaultProps = {
 };
 
 CloseIcon.propTypes = {
-  /**
-   * Handler when the user clicks the CloseIcon
-   */
+  /** @prop Handler when the user clicks the CloseIcon | () => {} */
   onClick: PropTypes.func,
 
-  /**
-   * optional css class string
-   */
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
 
 };

--- a/src/lib/Coachmark/index.js
+++ b/src/lib/Coachmark/index.js
@@ -155,13 +155,21 @@ Coachmark.defaultProps = {
 };
 
 Coachmark.propTypes = {
+  /** @prop Allows user to click outside of element | false */
   allowClickAway: PropTypes.bool,
+  /** @prop Button nodes within Coachmark | null */
   buttonChildren: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Children nodes to render inside Coachmark | null */
   children: PropTypes.node.isRequired,
+  /** @prop Allows Coachmark to be closed by a click from the user | false */
   closeOnClick: PropTypes.bool,
+  /** @prop Node with content that populates the Coachmark | null */
   contentNode: PropTypes.node,
+  /** @prop Sets the time the timer is delayed | 0 */
   delay: PropTypes.number,
+  /** @prop Sets the direction the Coachmark opens up | 'top-center' */
   direction: PropTypes.oneOf([
     'top-center',
     'top-left',
@@ -176,12 +184,19 @@ Coachmark.propTypes = {
     'right-top',
     'right-bottom'
   ]),
+  /** @prop Sets the header node of Coachmark | '' */
   header: PropTypes.node,
+  /** @prop Sets the time delay to hide the Coachmark | 0 */
   hideDelay: PropTypes.number,
+  /** @prop Sets the initial visibility of Coachmark | false */
   isOpen: PropTypes.bool,
+  /** @prop Sets the maximum width of Coachmark | null */
   maxWidth: PropTypes.number,
+  /** @prop Handler to be called when the user clicks the Coachmark | null */
   onClick: PropTypes.func,
+  /** @prop Shows visibility of the delay value | 0 */
   showDelay: PropTypes.number,
+  /** @prop Sets the subheader node of the Coachmark | '' */
   subheader: PropTypes.node,
 };
 

--- a/src/lib/CollapseButton/index.js
+++ b/src/lib/CollapseButton/index.js
@@ -38,9 +38,13 @@ CollapseButton.defaultProps = {
 };
 
 CollapseButton.propTypes = {
+  /** @prop Sets the collapse css styling | true */
   collapse: PropTypes.bool,
+  /** @prop Sets the positioning of the CollapseButton | 'left' */
   alignment: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
+  /** @prop Handler to be called when the user taps the CollapseButton | null */
   onClick: PropTypes.func,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
 };
 

--- a/src/lib/ComboBox/index.js
+++ b/src/lib/ComboBox/index.js
@@ -288,22 +288,36 @@ class ComboBox extends React.Component {
 }
 
 ComboBox.propTypes = {
+  /** @prop Children nodes to render inside ComboBox | null */
   children: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Sets the initial input element as empty | false */
   clear: PropTypes.bool,
+  /** @prop Sets the attribute disabled to the ComboBox | false */
   disabled: PropTypes.bool,
+  /** @prop Sets the ComboBox to have a search icon | true */
   hasSearchIcon: PropTypes.bool,
+  /** @prop Sets the ID of the ComboBox */
   id: PropTypes.string,
+  /** @prop Collection of props unique for Input element | null */
   inputProps: PropTypes.shape({}),
+  /** @prop Handler invoked when the user presses any key | null */
   onChange: PropTypes.func,
+  /** @prop Handler invoked when the user selects the ComboBox | null  */
   onSelect: PropTypes.func,
+  /** @prop Array of options for the ComboBox dropdown | [] */
   options: PropTypes.arrayOf(PropTypes.string),
+  /** @prop Text that initially populates the input field for guidence | ''  */
   placeholder: PropTypes.string,
+  /** @prop Sets the search prop | 'label' */
   searchProp: PropTypes.string,
+  /** @prop Sets the target offset | { horizontal: 0, vertical: 4 } */
   targetOffset: PropTypes.shape({
     horizontal: PropTypes.number,
     vertical: PropTypes.number,
   }),
+  /** @prop Sets the color theme of the ComboBox | '' */
   theme: PropTypes.string,
 };
 

--- a/src/lib/CompositeAvatar/index.js
+++ b/src/lib/CompositeAvatar/index.js
@@ -30,8 +30,11 @@ const CompositeAvatar = props => {
 CompositeAvatar.displayName = 'CompositeAvatar';
 
 CompositeAvatar.propTypes = {
+  /** @prop Children nodes to render inside CompositeAvatar | null */
   children: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Sets the size of the CompositeAvatar | 'medium' */
   size: PropTypes.oneOf(['small', 'medium', 'large', 28, 40, 84, 135]),
 };
 

--- a/src/lib/DatePicker/DatePickerCalendar/index.js
+++ b/src/lib/DatePicker/DatePickerCalendar/index.js
@@ -164,11 +164,17 @@ DatePickerCalendar.contextTypes = {
 };
 
 DatePickerCalendar.propTypes = {
+  /** @prop Sets the language for the DatePickerCalendar | 'en' */
   locale: PropTypes.string,
+  /** @prop Sets the last date in which the calendar does not disable | null */
   maxDate: PropTypes.instanceOf(Date),
+  /** @prop Sets the first date in which the calendar does not disable | null */
   minDate: PropTypes.instanceOf(Date),
+  /** @prop Sets the format in how the Month is displayed | null */
   monthFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  /** @prop Text to display for blindness accessibility features | 'next' */
   nextArialLabel: PropTypes.string,
+  /** @prop Text to display for blindness accessibility features | 'previous' */
   previousArialLabel: PropTypes.string,
 };
 

--- a/src/lib/DatePicker/DatePickerDay/index.js
+++ b/src/lib/DatePicker/DatePickerDay/index.js
@@ -62,7 +62,9 @@ DatePickerDay.contextTypes = {
 };
 
 DatePickerDay.propTypes = {
+  /** @prop Required day that the DatePickerDay displays */
   day: PropTypes.instanceOf(moment).isRequired,
+  /** @prop Required month that the DatePickerDay displays */
   month: PropTypes.number.isRequired,
 };
 

--- a/src/lib/DatePicker/DatePickerMonth/index.js
+++ b/src/lib/DatePicker/DatePickerMonth/index.js
@@ -51,6 +51,7 @@ class DatePickerMonth extends React.Component {
 }
 
 DatePickerMonth.propTypes = {
+  /** @prop Required day for the DatePickerMonth */
   day: PropTypes.instanceOf(moment).isRequired,
 };
 

--- a/src/lib/DatePicker/DatePickerWeek/index.js
+++ b/src/lib/DatePicker/DatePickerWeek/index.js
@@ -36,6 +36,7 @@ class DatePickerWeek extends React.PureComponent {
 }
 
 DatePickerWeek.propTypes = {
+  /** Required day for the DatePickerWeek */
   day: PropTypes.instanceOf(moment).isRequired,
 };
 

--- a/src/lib/DatePicker/index.js
+++ b/src/lib/DatePicker/index.js
@@ -20,14 +20,6 @@ import moment from 'moment';
 import { omit } from 'lodash';
 
 class DatePicker extends React.Component {
-  static displayName = 'DatePicker';
-
-  static childContextTypes = {
-    focus: PropTypes.instanceOf(moment),
-    handleDayClick: PropTypes.func,
-    handleMonthChange: PropTypes.func,
-    selected: PropTypes.instanceOf(moment),
-  };
 
   state = {
     anchorNode: null,
@@ -214,22 +206,39 @@ class DatePicker extends React.Component {
 
 
 DatePicker.propTypes = {
+  /** @prop Children nodes to render inside DatePicker | null */
   children: PropTypes.element,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Set the direction in which the DatePicker opens | 'bottom-center' */
   direction: PropTypes.string,
+  /** @prop Function to filter Dates | null */
   filterDate: PropTypes.func,
+  /** @prop Sets the DatePicker EventOverlay to be dynamic | true */
   isDynamic: PropTypes.bool,
+  /** @prop Sets the language of the DatePicker | 'en' */
   locale: PropTypes.string,
+  /** @prop Sets the last date in which the DatePicker does not disable | null */
   maxDate: PropTypes.instanceOf(Date),
+  /** @prop Sets the first date in which the DatePicker does not disable | null */
   minDate: PropTypes.instanceOf(Date),
+  /** @prop Sets the format of the month | 'MMMM YYYY' */
   monthFormat: PropTypes.string,
+  /** @prop Text to display for blindness accessibility features | 'next' */
   nextArialLabel: PropTypes.string,
+  /** @prop Handler invoked when user makes a chnage within the DatePicker | null */
   onChange: PropTypes.func,
+  /** @prop Handler invoked when user makes a change to the selected month within DatePicker | null */
   onMonthChange: PropTypes.func,
+  /** @prop Handler invoked when user selects a date within DatePicker | null */
   onSelect: PropTypes.func,
+  /** @prop Text to display for blindness accessibility features | 'previous' */
   previousArialLabel: PropTypes.string,
+  /** @prop Initial Selected Date for DatePicker | moment().toDate()  */
   selectedDate: PropTypes.instanceOf(Date),
+  /** @prop Determines if the DatePicker should close when a date is selected | true */
   shouldCloseOnSelect: PropTypes.bool,
+  /** @prop Determines if the DatePicker should show the open/close arrow | false */
   showArrow: PropTypes.bool,
 };
 
@@ -252,6 +261,16 @@ DatePicker.defaultProps = {
   shouldCloseOnSelect: true,
   showArrow: false,
 };
+
+DatePicker.childContextTypes = {
+  focus: PropTypes.instanceOf(moment),
+  handleDayClick: PropTypes.func,
+  handleMonthChange: PropTypes.func,
+  selected: PropTypes.instanceOf(moment),
+};
+
+DatePicker.displayName = 'DatePicker';
+
 
 export default DatePicker;
 

--- a/src/lib/EditableTextfield/index.js
+++ b/src/lib/EditableTextfield/index.js
@@ -149,33 +149,19 @@ class EditableTextfield extends React.Component {
 }
 
 EditableTextfield.propTypes = {
-  /**
-   * alignment modifier
-   */
+  /** @prop Alignment css modifier | 'left' */
   alignment: PropTypes.oneOf(['center', 'left', 'right']),
-  /**
-   * optional props for internal button
-   */
-  buttonProps: PropTypes.shape({}),
-  /**
-   * optional css class name for internal button
-   */
+  /** @ Optional css class name for internal button | null */
   buttonClassName: PropTypes.string,
-  /**
-   * css class names
-   */
+  /** @prop Optional props for internal button | '' */
+  buttonProps: PropTypes.shape({}),
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
-  /**
-   * optional disable
-   */
+  /** @prop Sets the disable attribute for EditableTextField | false */
   disabled: PropTypes.bool,
-  /**
-   * optional function for blur
-   */
+  /** @prop Optional function for blur | null */
   handleDoneEditing: PropTypes.func,
-  /**
-   * text to be shown
-   */
+  /** @prop Text to be shown within input field | null */
   inputText: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 

--- a/src/lib/ErrorBoundary/index.js
+++ b/src/lib/ErrorBoundary/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class ErrorBoundary extends React.Component {
-  static displayName = 'ErrorBoundary';
 
   state = { 
     error: null, 
@@ -52,16 +51,21 @@ class ErrorBoundary extends React.Component {
   }
 }
 
-ErrorBoundary.defaultProps = {
-  fallbackComponent: null,
-  errorCallback: null,
-  children: null
+ErrorBoundary.propTypes = {
+  /** @prop Children nodes to render inside the ErrorBoundary | null */
+  children: PropTypes.node,
+  /** @prop Callback function invoked when an error has occured | null */
+  errorCallback: PropTypes.func,
+  /** @prop Sets a backup Component in the case of a failure | null */
+  fallbackComponent: PropTypes.node,
 };
 
-ErrorBoundary.propTypes = {
-  fallbackComponent: PropTypes.node,
-  errorCallback: PropTypes.func,
-  children: PropTypes.node,
+ErrorBoundary.defaultProps = {
+  children: null,
+  errorCallback: null,
+  fallbackComponent: null
 };
+
+ErrorBoundary.displayName = 'ErrorBoundary';
 
 export default ErrorBoundary;

--- a/src/lib/EventOverlay/index.js
+++ b/src/lib/EventOverlay/index.js
@@ -617,34 +617,36 @@ EventOverlay.defaultProps = {
   checkOverflow: false,
   className: '',
   close: null,
+  direction: 'bottom-left',
+  isContained: false,
   isDynamic: false,
   isOpen: false,
-  isContained: false,
-  direction: 'bottom-left',
+  maxHeight: null,
+  maxWidth: null,
+  showArrow: false,
+  style: null,
   targetOffset: {
     horizontal: 0,
     vertical: 0
-  },
-  showArrow: false,
-  style: null,
-  maxHeight: null,
-  maxWidth: null
+  }
 };
 
 EventOverlay.propTypes = {
+  /** @prop Allows use to click outside of EventOverlay | true */
   allowClickAway: PropTypes.bool,
+  /** @prop Node in which the selection begins | null */
   anchorNode: PropTypes.object,
+  /** @prop Set to Check if children nodes are overflowing the EventOverlay | false */
   checkOverflow: PropTypes.bool,
+  /** @prop Children nodes to render inside the EventOverlay | null */
   children: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
+  /** @prop Function to close EventOverlay | null */
   close: PropTypes.func,
-  isDynamic: PropTypes.bool,
-  isOpen: PropTypes.bool,
-  isContained: PropTypes.bool,
-  targetOffset: PropTypes.shape({
-    horizontal: PropTypes.number,
-    vertical: PropTypes.number
-  }),
+  /** @prop Determines if the EventOverlay should close when clicked on | true */
+  closeOnClick: PropTypes.bool,
+  /** @prop Sets the direction in which the EventOverlay extends | 'bottom-left' */
   direction: PropTypes.oneOf([
     'top-center',
     'left-center',
@@ -659,9 +661,23 @@ EventOverlay.propTypes = {
     'right-top',
     'right-bottom'
   ]),
-  showArrow: PropTypes.bool,
-  style: PropTypes.object,
-  closeOnClick: PropTypes.bool,
+  /** @prop Determines if the contents of EventOverlay is contained within Component | false */
+  isContained: PropTypes.bool,
+  /** @prop Sets the EventOverlay to be a dynamic UI component | false */
+  isDynamic: PropTypes.bool,
+  /** @prop Sets the visibility of the EventOverlay | false */
+  isOpen: PropTypes.bool,
+  /** @prop Sets the max height of the EventOverlay | null */
   maxHeight: PropTypes.number,
-  maxWidth: PropTypes.number
+  /** @prop Sets the max width of the EventOverlay | null */
+  maxWidth: PropTypes.number,
+  /** @prop Determines if the EventOverlay should show the open/close arrow | false */
+  showArrow: PropTypes.bool,
+  /** @prop Optional css styling | null */
+  style: PropTypes.object,
+  /** @prop Sets the target offset | { horizontal: 0, vertical: 0 } */
+  targetOffset: PropTypes.shape({
+    horizontal: PropTypes.number,
+    vertical: PropTypes.number
+  }),
 };

--- a/src/lib/Footer/index.js
+++ b/src/lib/Footer/index.js
@@ -8,7 +8,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class Footer extends React.Component {
-  static displayName = 'Footer';
 
   render() {
     const { color, logo, copyright, social, className, children } = this.props;
@@ -44,22 +43,30 @@ export default class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-  color: PropTypes.string,
-  logo: PropTypes.node,
-  copyright: PropTypes.string,
-  social: PropTypes.node,
+  /** @prop Children nodes to render inside the Footer | null */
+  children: PropTypes.node,
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
-  children: PropTypes.node
+  /** @prop Optional color css styling | 'dark' */
+  color: PropTypes.string,
+  /** @prop Set the copyright within the Footer | '' */
+  copyright: PropTypes.string,
+  /** @prop Set the logo within the Footer | null */
+  logo: PropTypes.node,
+  /** @prop Node containing social media links | null */
+  social: PropTypes.node
 };
 
 Footer.defaultProps = {
-  color: 'dark',
-  logo: null,
-  copyright: '',
-  social: null,
+  children: null,
   className: '',
-  children: null
+  color: 'dark',
+  copyright: '',
+  logo: null,
+  social: null
 };
+
+Footer.displayName = 'Footer';
 
 /**
 * @name Footer

--- a/src/lib/Form/index.js
+++ b/src/lib/Form/index.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
  */
 
 class Form extends React.PureComponent {
-  static displayName = 'Form';
 
   render() {
     const { name, children, ...props } = this.props;
@@ -26,19 +25,18 @@ class Form extends React.PureComponent {
 }
 
 Form.propTypes = {
-  /**
-   * optional name prop type
-   */
-  name: PropTypes.string.isRequired,
-  /**
-   * optional children prop type
-   */
+  /** @prop Children node to render inside Form | null */
   children: PropTypes.node,
+  /** @prop Form name */
+  name: PropTypes.string.isRequired,
+
 };
 
 Form.defaultProps = {
   children: null,
 };
+
+Form.displayName = 'Form';
 
 export default Form;
 

--- a/src/lib/FormContent/index.js
+++ b/src/lib/FormContent/index.js
@@ -12,10 +12,12 @@ const FormContent = props => {
 };
 
 FormContent.propTypes = {
-  /**
-   * optional children prop type
-   */
+  /** @prop Children node to render inside FormContent | null */
   children: PropTypes.node,
+};
+
+FormContent.deafultProps = {
+  children: null,
 };
 
 FormContent.displayName = 'FormContent';

--- a/src/lib/FormInfo/index.js
+++ b/src/lib/FormInfo/index.js
@@ -17,19 +17,15 @@ const FormInfo = props => {
 };
 
 FormInfo.propTypes = {
-  /**
-   * optional title prop type
-   */
-  title: PropTypes.string,
-  /**
-   * optional description prop type
-   */
+  /** @prop Optional FormInfo description text | '' */
   description: PropTypes.string,
+  /** @prop Optional FormInfo title | '' */
+  title: PropTypes.string
 };
 
 FormInfo.defaultProps = {
-  title: '',
   description: '',
+  title: ''
 };
 
 FormInfo.displayName = 'FormInfo';

--- a/src/lib/FormSection/index.js
+++ b/src/lib/FormSection/index.js
@@ -23,23 +23,18 @@ const FormSection = props => {
 };
 
 FormSection.propTypes = {
-  /**
-   * optional title prop type
-   */
-  title: PropTypes.string.isRequired,
-  /**
-   * optional description prop type
-   */
-  description: PropTypes.string,
-  /**
-   * optional children prop type
-   */
+  /** @prop Children node to render inside FormSection | null */
   children: PropTypes.node,
+  /** @prop Optional FormSection description | '' */
+  description: PropTypes.string,
+  /** @prop Optional FormSection title | null */
+  title: PropTypes.string.isRequired
 };
 
 FormSection.defaultProps = {
-  description: '',
   children: null,
+  description: '',
+  title: null,
 };
 
 FormSection.displayName = 'FormSection';

--- a/src/lib/FormSubSection/index.js
+++ b/src/lib/FormSubSection/index.js
@@ -20,24 +20,18 @@ const FormSubSection = props => {
 };
 
 FormSubSection.propTypes = {
-  /**
-   * optional label prop type
-   */
-  label: PropTypes.string,
-  /**
-   * optional description prop type
-   */
-  description: PropTypes.string,
-  /**
-   * optional children prop type
-   */
+  /** @prop Children node to render inside FormSubSection | null */
   children: PropTypes.node,
+  /** @prop Optional FormSubSection description text | '' */
+  description: PropTypes.string,
+  /** @prop Optional FormSubSection label text | '' */
+  label: PropTypes.string,
 };
 
 FormSubSection.defaultProps = {
-  label: '',
-  description: '',
   children: null,
+  description: '',
+  label: ''
 };
 
 FormSubSection.displayName = 'FormSubSection';

--- a/src/lib/Icon/index.js
+++ b/src/lib/Icon/index.js
@@ -200,16 +200,27 @@ class Icon extends React.PureComponent {
 }
 
 Icon.propTypes = {
+  /** @prop Text to display for blindness accessibility features | null */
   ariaLabel: PropTypes.string,
+  /** @prop Optional Button class name string | '' */
   buttonClassName: PropTypes.string,
+  /** @prop Optional color css styling | '' */
   color: PropTypes.string,
+  /** @prop Optional class name string | '' */
   className: PropTypes.string,
+  /** @prop Icon description text | '' */
   description: PropTypes.string,
+  /** @prop Depreciated prop that supports accessibility features | true */
   isAria: PropTypes.bool, // TODO(pajeter): remove isAria code with next major release
+  /** @prop Required Icon name */
   name: PropTypes.string.isRequired,
+  /** @prop Handler invoked by click of the user | null */
   onClick: PropTypes.func,
+  /** @prop Sets Icon size | null */
   size: PropTypes.number,
+  /** @prop Sets Icon Title prop | '' */
   title: PropTypes.string,
+  /** @prop Sets Icon Type | '' */
   type: PropTypes.oneOf(['', 'white'])
 };
 

--- a/src/lib/Input/index.js
+++ b/src/lib/Input/index.js
@@ -29,7 +29,6 @@ const filterErrorsByType = (array, value) => {
 
 /** Text input with integrated label to enforce consistency in layout, error display, label placement, and required field marker. */
 class Input extends React.Component {
-  static displayName = 'Input';
 
   state = {
     isEditing: false,
@@ -262,6 +261,63 @@ class Input extends React.Component {
   }
 }
 
+Input.propTypes = {
+  /** @prop Child component to display next to the input | '' */
+  children: PropTypes.node,
+  /** @prop Optional css class name | '' */
+  className: PropTypes.string,
+  /** @prop Clears Input values | false */
+  clear: PropTypes.bool,
+  /** @prop Optional aria label on the clear button | null */
+  clearAriaLabel: PropTypes.string,
+  /** @prop Default Value same as value but used when onChange isn't invoked | '' */
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /*** @prop Sets the disabled attribute of the Input | false */
+  disabled: PropTypes.bool,
+  /** @prop Array of Objects with error and type [{error: '', type: ''}] to display error message and assign class | [] */
+  errorArr: PropTypes.array,
+  /** @prop Unique HTML ID used for tying label to HTML input for automated testing | null */
+  htmlId: PropTypes.string,
+  /** @prop Unique HTML ID ssed for tying label to HTML input | null */
+  id: PropTypes.string,
+  /** @prop Input css class name string | '' */
+  inputClassName: PropTypes.string,
+  /** @prop Help Text to show form validation rules | '' */
+  inputHelpText: PropTypes.string,
+  /*** @prop Optional Input ref prop type | null */
+  inputRef: PropTypes.func,
+  /** @prop Overall input group size | '' */
+  inputSize: PropTypes.string,
+  /** @prop Input label text | '' */
+  label: PropTypes.string,
+  /*** @prop Optional Input name prop type | null */
+  name: PropTypes.string,
+  /** @prop Set the level of nested Input components | 0 */
+  nestedLevel: PropTypes.number,
+  /** @prop Callback function invoked when user types into the Input field | null */
+  onChange: PropTypes.func,
+  /*** @prop Callback function invoked when user is done editing Input field | null */
+  onDoneEditing: PropTypes.func,
+  /*** @prop Callback function invoked when user focuses on the Input field | null */
+  onFocus: PropTypes.func,
+  /*** @prop Callback function invoked when user presses any key | null */
+  onKeyDown: PropTypes.func,
+  /*** @prop Callback function invoked when user clicks on the mouse/trackpad | null */
+  onMouseDown: PropTypes.func,
+  /** @prop Placeholder text to display when Input is empty | '' */
+  placeholder: PropTypes.string,
+  /*** @prop Determines if Input can be edited | false */
+  readOnly: PropTypes.bool,
+  /** @prop Secondary Input label | '' */
+  secondaryLabel: PropTypes.string,
+  /** @prop Input color theme | '' */
+  theme: PropTypes.string,
+  /** @prop Input type | 'text' */
+  type: PropTypes.oneOf(['text', 'number', 'password', 'email']),
+  /** @prop Input value | '' */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
 Input.defaultProps = {
   children: '',
   className: '',
@@ -270,6 +326,8 @@ Input.defaultProps = {
   defaultValue: '',
   disabled: false,
   errorArr: [],
+  htmlId: null,
+  id: null,
   inputClassName: '',
   inputHelpText: '',
   inputRef: null,
@@ -290,65 +348,7 @@ Input.defaultProps = {
   value: '',
 };
 
-Input.propTypes = {
-  /** Child component to display next to the input */
-  children: PropTypes.node,
-  /** Div Input ClassName */
-  className: PropTypes.string,
-  /** Clear */
-  clear: PropTypes.bool,
-  /** Optional aria label on the clear button */
-  clearAriaLabel: PropTypes.string,
-  /** Default Value same as value but used when onChange isn't */
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  /*** optional disabled prop type */
-  disabled: PropTypes.bool,
-  /** Includes Array of Objects with error and type
-   [{error: '', type: ''}] to display
-   error message and assign class
-   */
-  errorArr: PropTypes.array,
-  /** Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing. */
-  htmlId: PropTypes.string,
-  /** Unique HTML ID. Used for tying label to HTML input. */
-  id: PropTypes.string,
-  /** Div Input ClassName */
-  inputClassName: PropTypes.string,
-  /** Help Text to show form validation rules */
-  inputHelpText: PropTypes.string,
-  /*** optional ref prop type */
-  inputRef: PropTypes.func,
-  /** Overall input group size. */
-  inputSize: PropTypes.string,
-  /** Input label */
-  label: PropTypes.string,
-  /*** optional name prop type */
-  name: PropTypes.string,
-  /*** optional nextLevel prop type */
-  nestedLevel: PropTypes.number,
-  /** Function to call onChange */
-  onChange: PropTypes.func,
-  /*** optional function for blur prop type */
-  onDoneEditing: PropTypes.func,
-  /*** optional function for focus prop type */
-  onFocus: PropTypes.func,
-  /*** optional function for key up event */
-  onKeyDown: PropTypes.func,
-  /*** optional function for mouse down event */
-  onMouseDown: PropTypes.func,
-  /** Placeholder to display when empty */
-  placeholder: PropTypes.string,
-  /*** optional read-only prop type */
-  readOnly: PropTypes.bool,
-  /** Secondary Input label */
-  secondaryLabel: PropTypes.string,
-  /** theme prop type */
-  theme: PropTypes.string,
-  /** Input type */
-  type: PropTypes.oneOf(['text', 'number', 'password', 'email']),
-  /** Value */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
+Input.displayName = 'Input';
 
 export default Input;
 

--- a/src/lib/InputError/index.js
+++ b/src/lib/InputError/index.js
@@ -11,7 +11,7 @@ const InputError = ({ error }) => {
 };
 
 InputError.propTypes = {
-  /** Error for input */
+  /** @prop Error message for InputError component */
   error: PropTypes.string.isRequired,
 };
 

--- a/src/lib/InputHelper/index.js
+++ b/src/lib/InputHelper/index.js
@@ -11,15 +11,16 @@ const InputHelper = ({ message, className }) => {
   return <p className={`cui-input__help-text ${className}`}>{message}</p>;
 };
 
-InputHelper.defaultProps = {
-  className: '',
+InputHelper.propTypes = {
+  /** @prop Optional css class name | '' */
+  className: PropTypes.string,
+  /** @prop Input help message for parent Input | null */
+  message: PropTypes.string.isRequired
 };
 
-InputHelper.propTypes = {
-  /** Message for parent input */
-  message: PropTypes.string.isRequired,
-  /** HTML Class for associated paragraph */
-  className: PropTypes.string,
+InputHelper.defaultProps = {
+  className: '',
+  message: null,
 };
 
 InputHelper.displayName = 'InputHelper';

--- a/src/lib/Label/index.js
+++ b/src/lib/Label/index.js
@@ -22,20 +22,22 @@ const Label = ({ className, htmlFor, label, theme, ...props }) => {
   );
 };
 
-Label.defaultProps = {
-  className: '',
-  theme: '',
+Label.propTypes = {
+  /** @prop HTML class name for associated Input | '' */
+  className: PropTypes.string,
+  /** @prop HTML ID for associated Input | null */
+  htmlFor: PropTypes.string.isRequired,
+  /** @prop Required Label text | null */
+  label: PropTypes.string.isRequired,
+  /** @prop Set Label's color theme | '' */
+  theme: PropTypes.string,
 };
 
-Label.propTypes = {
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** HTML ID for associated input */
-  htmlFor: PropTypes.string.isRequired,
-  /** Label text */
-  label: PropTypes.string.isRequired,
-  /** theme prop type */
-  theme: PropTypes.string,
+Label.defaultProps = {
+  className: '',
+  htmlFor: null,
+  label: null,
+  theme: '',
 };
 
 Label.displayName = 'Label';

--- a/src/lib/Lightbox/index.js
+++ b/src/lib/Lightbox/index.js
@@ -4,7 +4,6 @@ import Modal from 'react-aria-modal';
 import { Spinner, Tooltip, Icon } from '@collab-ui/react';
 
 class Lightbox extends React.Component {
-  static displayName = 'Lightbox';
 
   state = {
     viewportDimensions: {
@@ -491,19 +490,33 @@ class Lightbox extends React.Component {
 }
 
 Lightbox.propTypes = {
+  /** @prop ID for Lightbox query lookup */
+  applicationId: PropTypes.string.isRequired,
+  /** Determines if info is decrypting | false */
+  decrypting: PropTypes.bool,
+  /** @prop Optional downloading css styling | false */
   downloading: PropTypes.bool,
+  /** @prop Set Height value of Lightbox */
   height: PropTypes.number.isRequired,
+  /** @prop Initial index of start page | 0 */
   index: PropTypes.number,
+  /** @prop Lightbox information Object | {} */
   info: PropTypes.shape({
     sharedBy: PropTypes.string,
     sharedOn: PropTypes.string,
     size: PropTypes.string
   }),
+  /** @prop Required name prop for Lightbox */
   name: PropTypes.string.isRequired,
+  /** @prop Callback function invoked by user when interact with Lightbox | null */
   onChange: PropTypes.func,
+  /** @prop Callback function invoked by user closing the Lightbox | null */
   onClose: PropTypes.func,
+  /** @prop Callback function invoked by the download action of Lightbox | null */
   onDownload: PropTypes.func,
+  /** @prop Array of Lightbox pages */
   pages: PropTypes.array.isRequired,
+  /** @prop Collection of predefined tootips for various Lightbox actions | { download: 'Download', etc } */
   tooltips: PropTypes.shape({
     download: PropTypes.string,
     downloading: PropTypes.string,
@@ -513,8 +526,8 @@ Lightbox.propTypes = {
     zoomIn: PropTypes.string,
     zoomOut: PropTypes.string
   }),
+  /** @prop Set Width value for Lightbox */
   width: PropTypes.number.isRequired,
-  applicationId: PropTypes.string.isRequired,
 };
 
 Lightbox.defaultProps = {
@@ -536,6 +549,8 @@ Lightbox.defaultProps = {
     zoomOut: 'Zoom out'
   },
 };
+
+Lightbox.displayName = 'Lightbox';
 
 export default Lightbox;
 

--- a/src/lib/Link/index.js
+++ b/src/lib/Link/index.js
@@ -26,27 +26,28 @@ const Link = ({ className, children, color, disabled, tag, theme, ...props }) =>
   );
 };
 
+Link.propTypes = {
+  /** @prop Children nodes to render inside Link Component | null */
+  children: PropTypes.node.isRequired,
+  /** @prop Optional css class string | '' */
+  className: PropTypes.string,
+  /** @prop Optional color css styling | 'blue' */
+  color: PropTypes.string,
+  /** @prop Sets the attribute disabled to the Link | false */
+  disabled: PropTypes.bool,
+  /** @prop Set HTML tag type | 'a' */
+  tag: PropTypes.oneOf(['a', 'div', 'span']),
+  /** @prop Set Link theme | ''  */
+  theme: PropTypes.string,
+};
+
 Link.defaultProps = {
+  children: null,
   className: '',
   color: 'blue',
   disabled: false,
   tag: 'a',
   theme: ''
-};
-
-Link.propTypes = {
-  /** Link children */
-  children: PropTypes.node.isRequired,
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** color prop type */
-  color: PropTypes.string,
-  /** theme prop type */
-  theme: PropTypes.string,
-  /** Sets the attribute disabled to the link */
-  disabled: PropTypes.bool,
-  /** optional tag prop type */
-  tag: PropTypes.oneOf(['a', 'div', 'span']),
 };
 
 Link.displayName = 'Link';

--- a/src/lib/List/index.js
+++ b/src/lib/List/index.js
@@ -9,7 +9,6 @@ import { omit, uniqueId } from 'lodash';
  */
 
 class List extends React.Component {
-  static displayName = 'List';
 
   static childContextTypes = {
     setSelected: PropTypes.func,
@@ -296,41 +295,31 @@ class List extends React.Component {
   }
 }
 
-List.contextTypes = {
-  /** optional visible class prop type */
-  visibleClass: PropTypes.string
-};
-
 List.propTypes = {
-  /** optional active prop to pass active prop to children */
+  /** @prop Optional active prop to pass active prop to children | null */
   active: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.array
   ]),
-  /** optional children prop type */
+  /** @prop Children nodes to render inside List | null */
   children: PropTypes.node,
-  /** optional className prop type */
+  /** @prop Optional css class string | '' */
   className: PropTypes.string,
-  /** optional focusFirst prop type */
+  /** @prop Sets first List item to have focus | true */
   focusFirst: PropTypes.bool,
-  /** optional id prop */
+  /** @prop Optional ID value of List | null */
   id: PropTypes.string,
-  /** optional prop to know if multiple children can be active */
+  /** @prop Optional prop to know if multiple children can be active | false */
   isMulti: PropTypes.bool,
-  /** optional tabType prop type to manually set child role */
+  /** @prop Optional tabType prop type to manually set child role | 'listItem' */
   itemRole: PropTypes.string,
-  /** optional onSelect prop type */
+  /** @prop Callback function invoked by user selecting an interactive item within List | null */
   onSelect: PropTypes.func,
-  /**
-   * ARIA role for the Nav, in the context of a TabContainer, the default will
-   * be set to "listItem", but can be overridden by the Nav when set explicitly.
-   *
-   * When the role is set to "listItem"
-   */
+  /** @prop Sets the ARIA role for the Nav, in the context of a TabContainer | 'list' */
   role: PropTypes.string,
-  /** optional tabType prop type defaults to horizontal */
+  /** @prop Sets the orientation of the List | 'vertical' */
   tabType: PropTypes.oneOf(['vertical', 'horizontal']),
-  /** ListItem Size */
+  /** @prop Sets List size | null */
   type: PropTypes.oneOf(['small', 'large', 'space', 'xlarge']),
 };
 
@@ -347,5 +336,11 @@ List.defaultProps = {
   tabType: 'vertical',
   type: null,
 };
+
+List.contextTypes = {
+  visibleClass: PropTypes.string
+};
+
+List.displayName = 'List';
 
 export default List;

--- a/src/lib/ListItem/index.js
+++ b/src/lib/ListItem/index.js
@@ -10,7 +10,6 @@ import { omit, uniqueId } from 'lodash';
  */
 
 class ListItem extends React.Component {
-  static displayName = 'ListItem';
 
   state = {
     id: this.props.id || uniqueId('cui-list-item-'),
@@ -224,9 +223,54 @@ class ListItem extends React.Component {
   }
 }
 
-ListItem.contextTypes = {
-  setSelected: PropTypes.func,
-  handleListKeyDown: PropTypes.func
+ListItem.propTypes = {
+  /** @prop Active prop to help determine styles | false */
+  active: PropTypes.bool,
+  /** @prop Children nodes to render inside ListItem | null  */
+  children: PropTypes.node,
+  /** @prop Optional css class string | '' */
+  className: PropTypes.string,
+  /** @prop Node in which the selection begins | null */
+  customAnchorNode: PropTypes.element,
+  /** @prop ListItem Custom Prop Name for child with custom Ref | null */
+  customRefProp: PropTypes.string,
+  /** @prop Disabled attribute for ListItem to determine styles | false */
+  disabled: PropTypes.bool,
+  /** @prop Specifies if ListItem should automatically get focus | false */
+  focus: PropTypes.bool,
+  /** @prop Specifies if ListItem should automatically get focus when page loads | false */
+  focusOnLoad: PropTypes.bool,
+  /** @prop Sets ListItem id | null */
+  id: PropTypes.string,
+  /** @prop Determines if ListItem is clickable | false */
+  isReadOnly: PropTypes.bool,
+  /** @prop ListItem index number | null */
+  itemIndex: PropTypes.number,
+  /** @prop ListItem label text | '' */
+  label: PropTypes.string,
+  /** @prop external link associated input | '' */
+  link: PropTypes.string,
+  /** @prop Callback function invoked by user tapping on ListItem | null */
+  onClick: PropTypes.func,
+  /** @prop Callback function invoked by user pressing on a key | null */
+  onKeyDown: PropTypes.func,
+  /** @prop ListItem ref name | 'navLink' */
+  refName: PropTypes.string,
+  /** @prop Aria role | 'listItem' */
+  role: PropTypes.string,
+  /** @prop Prop that controls whether to show separator or not | false */
+  separator: PropTypes.bool,
+  /** @prop ListItem Title | '' */
+  title: PropTypes.string,
+  /** @prop ListItem size | '' */
+  type: PropTypes.oneOf(['', 'small', 'large', 'xlarge', 'space', 'header', 36, 52, 60]),
+  /** @prop ListItem value for OnSelect value | '' */
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.object,
+    PropTypes.array
+  ]),
 };
 
 ListItem.defaultProps = {
@@ -253,55 +297,12 @@ ListItem.defaultProps = {
   value: '',
 };
 
-ListItem.propTypes = {
-  /** Active prop to help determine styles */
-  active: PropTypes.bool,
-  /** children prop */
-  children: PropTypes.node,
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** Class Name for Nav Link */
-  customAnchorNode: PropTypes.element,
-  /** ListItem Custom Prop Name for child with custom Ref */
-  customRefProp: PropTypes.string,
-  /** Disabled prop to help determine styles */
-  disabled: PropTypes.bool,
-  /** Focus prop to help determine styles */
-  focus: PropTypes.bool,
-  /** Focus bool to determine if Focus should happen on load */
-  focusOnLoad: PropTypes.bool,
-  /** ListItem id */
-  id: PropTypes.string,
-  /** Prop bool to determine if ListItem is clickable */
-  isReadOnly: PropTypes.bool,
-  /** ListItem number */
-  itemIndex: PropTypes.number,
-  /** ListItem text */
-  label: PropTypes.string,
-  /** external link associated input */
-  link: PropTypes.string,
-  /** onClick function */
-  onClick: PropTypes.func,
-  /** onKeyDown function */
-  onKeyDown: PropTypes.func,
-  /** ListItem ref name */
-  refName: PropTypes.string,
-  /** aria role */
-  role: PropTypes.string,
-  /** prop that controls whether to show separator or not */
-  separator: PropTypes.bool,
-  /** ListItem Title */
-  title: PropTypes.string,
-  /** ListItem Type */
-  type: PropTypes.oneOf(['', 'small', 'large', 'xlarge', 'space', 'header', 36, 52, 60]),
-  /** ListItem Value for OnSelect Value */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.object,
-    PropTypes.array
-  ]),
+ListItem.contextTypes = {
+  setSelected: PropTypes.func,
+  handleListKeyDown: PropTypes.func
 };
+
+ListItem.displayName = 'ListItem';
 
 export default ListItem;
 

--- a/src/lib/ListItemHeader/index.js
+++ b/src/lib/ListItemHeader/index.js
@@ -12,7 +12,6 @@ import {
  * @variations collab-ui-react
  */
 class ListItemHeader extends React.PureComponent {
-  static displayName = 'ListItemHeader';
 
   state = {
     id: this.props.id || uniqueId('cui-space-list-item__header-'),
@@ -67,6 +66,23 @@ class ListItemHeader extends React.PureComponent {
   }
 }
 
+ListItemHeader.propTypes = {
+  /** @prop Children nodes to render inside ListItemHeader | null */
+  children: PropTypes.node,
+  /** @prop Optional css class string | '' */
+  className: PropTypes.string,
+  /** @prop ListItem header text */
+  header: PropTypes.string.isRequired,
+  /** @prop HTML ID for associated input | '' */
+  id: PropTypes.string,
+  /** @prop Determines if ListItemHeader is Clickable | true */
+  isReadOnly: PropTypes.bool,
+  /** @prop ListItem title | '' */
+  title: PropTypes.string,
+  /** @prop ListItemHeader type variation | '' */
+  type: PropTypes.oneOf(['', 'space']),
+};
+
 ListItemHeader.defaultProps = {
   children: null,
   className: '',
@@ -76,23 +92,7 @@ ListItemHeader.defaultProps = {
   type: ''
 };
 
-ListItemHeader.propTypes = {
-  /** ListItemHeader Children */
-  children: PropTypes.node,
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** ListItem header */
-  header: PropTypes.string.isRequired,
-  /** HTML ID for associated input */
-  id: PropTypes.string,
-  /** ListItemHeader Bool */
-  isReadOnly: PropTypes.bool,
-  /** ListItem title */
-  title: PropTypes.string,
-  /** ListItemHeader type variation */
-  type: PropTypes.oneOf(['', 'space']),
-};
-
+ListItemHeader.displayName = 'ListItemHeader';
 
 export default ListItemHeader;
 

--- a/src/lib/ListItemMeeting/index.js
+++ b/src/lib/ListItemMeeting/index.js
@@ -17,7 +17,6 @@ import {
  */
 
 class ListItemMeeting extends React.PureComponent {
-  static displayName = 'ListItemMeeting';
 
   state = {
     id: this.props.id || uniqueId('cui-list-item__meeting-'),
@@ -202,11 +201,60 @@ class ListItemMeeting extends React.PureComponent {
   }
 }
 
+ListItemMeeting.propTypes = {
+  /** @prop Callback function invoked when user taps on anchor link | '' */
+  anchorOnClick: PropTypes.func,
+  /** @prop ListItemMeeting Anchor link text | '' */
+  anchorLabel: PropTypes.string,
+  /** @prop Children nodes to render on the right inside ListItemMeeting | null */
+  childrenRight: PropTypes.node,
+  /** @prop Optional css class string | '' */
+  className: PropTypes.string,
+  /** @prop Date string | null */
+  date: PropTypes.string,
+  /** @prop Event Overlay props to be overwritten | null */
+  eventOverlayProps: PropTypes.shape({}),
+  /** @prop ListItem header text */
+  header: PropTypes.string.isRequired,
+  /** @prop HTML ID for ListItemMeeting | '' */
+  id: PropTypes.string,
+  /** @prop Determines if the ListItemMeeting includes the date | false */
+  includeDate: PropTypes.bool,
+  /** @prop Determines if the ListItemMeeting is in progress | false */
+  inProgress: PropTypes.bool,
+  /** @prop Determines if the ListItemMeeting is all day | false */
+  isAllDay: PropTypes.bool,
+  /** @prop Determines if the ListItemMeeting is recurring | false */
+  isRecurring: PropTypes.bool,
+  /** @prop Determines if the ListItemMeeting has Completed | false */
+  isCompleted: PropTypes.bool,
+  /** @prop Callback function invoked when user taps on ListItemMeeting | null */
+  onClick: PropTypes.func,
+  /** @prop ListItemMeeting Popover Content | null */
+  popoverContent: PropTypes.node,
+  /** @prop EventOverlay Ratio of Offset | -.4 */
+  ratioOffset: PropTypes.number,
+  /** @prop Sets the status Color | null */
+  statusColor: PropTypes.string,
+  /** @prop Set the Time Object | { start: '', end: '' } */
+  time: PropTypes.shape({
+    start: PropTypes.string,
+    end: PropTypes.string
+  }),
+  /** @prop Set the Time Node | null */
+  timeNode: PropTypes.node,
+  /** @prop ListItemMeeting title | '' */
+  title: PropTypes.string,
+  /** @prop ListItemMeeting Type | '' */
+  type: PropTypes.oneOf(['chip', '']),
+};
+
 ListItemMeeting.defaultProps = {
   anchorOnClick: null,
   anchorLabel: '',
   childrenRight: null,
   className: '',
+  date: null,
   eventOverlayProps: null,
   header: '',
   id: '',
@@ -228,54 +276,7 @@ ListItemMeeting.defaultProps = {
   type: '',
 };
 
-ListItemMeeting.propTypes = {
-  /** ListItemMeeting Anchor string */
-  anchorLabel: PropTypes.string,
-  /** ListItemMeeting Anchor Click */
-  anchorOnClick: PropTypes.func,
-  /** Children for right section */
-  childrenRight: PropTypes.node,
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** Date string */
-  date: PropTypes.string,
-  /** Event Overlay props to be overwritten */
-  eventOverlayProps: PropTypes.shape({}),
-  /** ListItem header */
-  header: PropTypes.string.isRequired,
-  /** HTML ID for associated input */
-  id: PropTypes.string,
-  /** ListItemMeeting Boolean */
-  includeDate: PropTypes.bool,
-  /** ListItemMeeting Boolean */
-  inProgress: PropTypes.bool,
-  /** ListItemMeeting Boolean */
-  isAllDay: PropTypes.bool,
-  /** ListItemMeeting Boolean */
-  isRecurring: PropTypes.bool,
-  /** ListItemMeeting Boolean */
-  isCompleted: PropTypes.bool,
-  /** ListItemMeeting OnClick */
-  onClick: PropTypes.func,
-  /** ListItemMeeting Popover Content */
-  popoverContent: PropTypes.node,
-  /** EventOverlay Ratio of Offset */
-  ratioOffset: PropTypes.number,
-  /** Status Color  */
-  statusColor: PropTypes.string,
-  /** Time Object */
-  time: PropTypes.shape({
-    start: PropTypes.string,
-    end: PropTypes.string
-  }),
-  /** Time Node */
-  timeNode: PropTypes.node,
-  /** ListItem title */
-  title: PropTypes.string,
-  /** Type  */
-  type: PropTypes.oneOf(['chip', '']),
-};
-
+ListItemMeeting.displayName = 'ListItemMeeting';
 
 export default ListItemMeeting;
 

--- a/src/lib/ListItemSection/index.js
+++ b/src/lib/ListItemSection/index.js
@@ -27,8 +27,11 @@ const ListItemSection = props => {
 };
 
 ListItemSection.propTypes = {
+  /** @prop Children nodes to render inside ListItemSection | null */
   children: PropTypes.node,
+  /** @prop Optional css class name | '' */
   className: PropTypes.string,
+  /** @prop Determine the ListItemSection's position | 'center' */
   position: PropTypes.oneOf(['left', 'center', 'right', 'center-align']),
 };
 

--- a/src/lib/ListSeparator/index.js
+++ b/src/lib/ListSeparator/index.js
@@ -52,12 +52,19 @@ const ListSeparator = props => {
 };
 
 ListSeparator.propTypes = {
+  /** @prop Children nodes to render inside ListSeparator | null */
   children: PropTypes.node,
+  /** @prop Optional css class name | null */
   className: PropTypes.string,
+  /** @prop Color of the ListSeparator line | null */
   lineColor: PropTypes.string,
+  /** @prop Margin of the ListSeparator | null */
   margin: PropTypes.string,
+  /** @prop Text of the ListSeparator | null */
   text: PropTypes.string,
+  /** @prop TextColor of the ListSeparator | null */
   textColor: PropTypes.string,
+  /** @prop Padding around text of the ListSeparator | null */
   textPadding:PropTypes.string,
 };
 

--- a/src/lib/Loading/index.js
+++ b/src/lib/Loading/index.js
@@ -22,9 +22,7 @@ const Loading = props => {
 };
 
 Loading.propTypes = {
-  /**
-   * Prop to make the loading animation small
-   */
+  /** @prop Prop to make the Loading animation small | false */
   small: PropTypes.bool,
 };
 

--- a/src/lib/Menu/index.js
+++ b/src/lib/Menu/index.js
@@ -9,12 +9,6 @@ import { isEqual } from 'lodash';
  */
 
 export default class Menu extends React.Component {
-  static displayName = 'Menu';
-
-  static childContextTypes = {
-    handleClick: PropTypes.func,
-    handleKeyDown: PropTypes.func
-  };
 
   state = {
     menuIndex: []
@@ -254,13 +248,12 @@ export default class Menu extends React.Component {
   }
 }
 
-Menu.contextTypes = {
-  onSelect: PropTypes.func,
-};
-
 Menu.propTypes = {
+  /** @prop Text to display for accessibility features | ''  */
   ariaLabel: PropTypes.string,
+  /** @prop Children nodes to render inside Menu | null */
   children: PropTypes.node,
+  /** @prop Optional css class name | '' */
   className: PropTypes.string,
 };
 
@@ -269,3 +262,14 @@ Menu.defaultProps = {
   children: null,
   className: '',
 };
+
+Menu.contextTypes = {
+  onSelect: PropTypes.func,
+};
+
+Menu.childContextTypes = {
+  handleClick: PropTypes.func,
+  handleKeyDown: PropTypes.func
+};
+
+Menu.displayName = 'Menu';

--- a/src/lib/MenuContent/index.js
+++ b/src/lib/MenuContent/index.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
  */
 
 class MenuContent extends React.PureComponent {
-  static displayName = 'MenuContent';
 
   render() {
     const { children, className, ...props } = this.props;
@@ -29,7 +28,9 @@ class MenuContent extends React.PureComponent {
 }
 
 MenuContent.propTypes = {
+  /** @prop Children nodes to render inside MenuContent component | null */
   children: PropTypes.node,
+  /** @prop Optional css class name | '' */
   className: PropTypes.string
 };
 
@@ -37,5 +38,7 @@ MenuContent.defaultProps = {
   children: null,
   className: '',
 };
+
+MenuContent.displayName = 'MenuContent';
 
 export default MenuContent;

--- a/src/lib/MenuItem/index.js
+++ b/src/lib/MenuItem/index.js
@@ -4,7 +4,6 @@ import { omit } from 'lodash';
 import { ListItem } from '@collab-ui/react/';
 
 class MenuItem extends React.Component {
-  static displayName = 'MenuItem';
 
   state = {
     anchorRef: null,
@@ -80,26 +79,31 @@ class MenuItem extends React.Component {
   }
 }
 
-MenuItem.contextTypes = {
-  handleClick: PropTypes.func,
-  handleKeyDown: PropTypes.func,
-};
-
 MenuItem.propTypes = {
+  /** @prop Children nodes to render inside MenuItem | null */
   children: PropTypes.node,
+  /** @prop Optional css class name | '' */
   className: PropTypes.string,
+  /** @prop Index value of MenuItem | null */
   index: PropTypes.array,
+  /** @prop Determines if MenuItem is the header | false */
   isHeader: PropTypes.bool,
+  /** @prop Determines if MenuItem is open | false */
   isOpen: PropTypes.bool,
+  /** @prop Set to keep the MenuItem open | false */
   keepMenuOpen: PropTypes.bool,
+  /** @prop label text of MenuItem | '' */
   label: PropTypes.string,
+  /** @prop Callback function invoked when user taps on MenutItem | null */
   onClick: PropTypes.func,
+  /** @prop MenuItem value | '' */
   value: PropTypes.string,
 };
 
 MenuItem.defaultProps = {
   children: null,
   className: '',
+  index: null,
   isHeader: false,
   isOpen: false,
   keepMenuOpen: false,
@@ -107,5 +111,12 @@ MenuItem.defaultProps = {
   onClick: null,
   value: '',
 };
+
+MenuItem.contextTypes = {
+  handleClick: PropTypes.func,
+  handleKeyDown: PropTypes.func,
+};
+
+MenuItem.displayName = 'MenuItem';
 
 export default MenuItem;

--- a/src/lib/MenuOverlay/index.js
+++ b/src/lib/MenuOverlay/index.js
@@ -10,7 +10,6 @@ import { EventOverlay } from '@collab-ui/react';
  */
 
 class MenuOverlay extends React.Component {
-  static displayName = 'MenuOverlay';
 
   static childContextTypes = {
     onSelect: PropTypes.func,
@@ -101,10 +100,15 @@ class MenuOverlay extends React.Component {
 }
 
 MenuOverlay.propTypes = {
+  /** @prop Children nodes to render inside MenuOverlay | null */
   children: PropTypes.node,
+  /** @prop Optional css class name | '' */
   className: PropTypes.string,
+  /** @prop HTML element that provides control to MenuOverlay user  */
   menuTrigger: PropTypes.element.isRequired,
+  /** @prop Callback function invoked when user selects MenuOverlay | null */
   onSelect: PropTypes.func,
+  /** @prop Determines if the MenuOverlay should show the open/close arrow | true */
   showArrow: PropTypes.bool,
 };
 
@@ -114,6 +118,8 @@ MenuOverlay.defaultProps = {
   onSelect: null,
   showArrow: true,
 };
+
+MenuOverlay.displayName = 'MenuOverlay';
 
 export default MenuOverlay;
 

--- a/src/lib/Modal/index.js
+++ b/src/lib/Modal/index.js
@@ -12,7 +12,6 @@ import AriaModal from 'react-aria-modal';
  */
 
 class Modal extends React.Component {
-  static displayName = 'Modal';
 
   static childContextTypes = {
     handleClose: PropTypes.func
@@ -121,6 +120,35 @@ class Modal extends React.Component {
   }
 }
 
+Modal.propTypes = {
+  /** @prop application DOM id, used to set aria-hidden to true when modal is open */
+  applicationId: PropTypes.string.isRequired,
+  /** @prop Determines the visibility and ability to edit the backdrop of the Modal | true */
+  backdrop: PropTypes.bool,
+  /** @prop To enable/disable clicking on underlay to exit modal | false */
+  backdropClickExit: PropTypes.bool,
+  /** @prop Children nodes to render inside the Modal | null */
+  children: PropTypes.node,
+  /** @prop Optional css class names | '' */
+  className: PropTypes.string,
+  /** @prop To enable/disable escape to exit modal | true */
+  escapeExits: PropTypes.bool,
+  /** @prop To set focus to the entire modal rather than elements within modal | true */
+  focusDialog: PropTypes.bool,
+  /** @prop Unique HTML ID used for tying label to HTML input for automated testing */
+  htmlId: PropTypes.string.isRequired,
+  /** @prop Icon node to be rendered for Dialog | null */
+  icon: PropTypes.element,
+  /** @prop Callback function invoked when user clicks on cross button or esc key */
+  onHide: PropTypes.func.isRequired,
+  /** @prop To render to an element other than the browser window | null */
+  renderTo: PropTypes.string,
+  /** @prop Show/hide modal */
+  show: PropTypes.bool.isRequired,
+  /** @prop Size of the modal | 'default' */
+  size: PropTypes.oneOf(['large', 'medium', 'default', 'small', 'full', 'dialog']),
+};
+
 Modal.defaultProps = {
   backdrop: true,
   backdropClickExit: false,
@@ -134,64 +162,7 @@ Modal.defaultProps = {
   size: 'default',
 };
 
-Modal.propTypes = {
-    /**
-   * application DOM id, used to set aria-hidden to true when modal is open.
-   */
-  applicationId: PropTypes.string.isRequired,
-  /**
-   *  To show/hide backdrop of the modal.
-   *  if backdrop is false then modal will become normal popup without backdrop and user can perform any action in parent screen.
-   */
-  backdrop: PropTypes.bool,
-  /**
-   *  To enable/disable clicking on underlay to exit modal
-   *
-   */
-  backdropClickExit: PropTypes.bool,
-  /**
-   * Children components
-   */
-  children: PropTypes.node,
-  /**
-   * css class names
-   */
-  className: PropTypes.string,
-  /**
-   *  To enable/disable escape to exit modal
-   *
-   */
-  escapeExits: PropTypes.bool,
-  /**
-   * To set focus to the entire modal rather than elements within modal
-   */
-  focusDialog: PropTypes.bool,
-  /**
-   * Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing. 
-   */
-  htmlId: PropTypes.string.isRequired,
-  /**
-   * Icon node to be rendered for Dialog
-   */
-  icon: PropTypes.element,
-  /**
-   * callback function invoked on close of the modal. modal can be closed on click of cross button or esc key.
-   * onHide is mandatory props, if not passed modal can not be closed.
-   */
-  onHide: PropTypes.func.isRequired,
-  /**
-   * To render to an element other than the window
-   */
-  renderTo: PropTypes.string,
-  /**
-   * show/hide modal.
-   */
-  show: PropTypes.bool.isRequired,
-  /**
-   * size of the modal.
-   */
-  size: PropTypes.oneOf(['large', 'medium', 'default', 'small', 'full', 'dialog']),
-};
+Modal.displayName = 'Modal';
 
 export default Modal;
 

--- a/src/lib/ModalBody/index.js
+++ b/src/lib/ModalBody/index.js
@@ -26,13 +26,9 @@ const ModalBody = props => {
 };
 
 ModalBody.propTypes = {
-  /**
-   * Children components
-   */
+  /** @prop Children nodes to render inside the ModalBody | null */
   children: PropTypes.node,
-  /**
-   * css class names
-   */
+  /** @prop Optional css class names | '' */
   className: PropTypes.string,
 };
 

--- a/src/lib/ModalFooter/index.js
+++ b/src/lib/ModalFooter/index.js
@@ -20,20 +20,16 @@ const ModalFooter = props => {
   );
 };
 
+ModalFooter.propTypes = {
+  /** @prop Children nodes to render inside of ModalFooter | null */
+  children: PropTypes.node,
+  /** @prop Optional css class names | '' */
+  className: PropTypes.string,
+};
+
 ModalFooter.defaultProps = {
   children: null,
   className: '',
-};
-
-ModalFooter.propTypes = {
-  /**
-   * Children components
-   */
-  children: PropTypes.node,
-  /**
-   * S classnames
-   */
-  className: PropTypes.string,
 };
 
 ModalFooter.displayName = 'ModalFooter';

--- a/src/lib/ModalHeader/index.js
+++ b/src/lib/ModalHeader/index.js
@@ -44,8 +44,17 @@ class ModalHeader extends React.PureComponent {
   }
 }
 
-ModalHeader.contextTypes = {
-  handleClose: PropTypes.func,
+ModalHeader.propTypes = {
+  /** @prop Children nodes to render inside of ModalHeader | null */
+  children: PropTypes.node,
+  /** @prop Optional CSS class names | '' */
+  className: PropTypes.string,
+  /** @prop ModalHeader label text | '' */
+  headerLabel: PropTypes.string,
+   /** @prop Modal message | '' */
+  message: PropTypes.string,
+  /** @prop show/hide close button | true */
+  showCloseButton: PropTypes.bool
 };
 
 ModalHeader.defaultProps = {
@@ -56,27 +65,8 @@ ModalHeader.defaultProps = {
   showCloseButton: true,
 };
 
-ModalHeader.propTypes = {
-  /**
-   * header label.
-   */
-  children: PropTypes.node,
-  /**
-   * CSS classnames
-   */
-  className: PropTypes.string,
-  /**
-   * header label.
-   */
-  headerLabel: PropTypes.string,
-   /**
-   * message label.
-   */
-  message: PropTypes.string,
-  /**
-   * show/hide close button
-   */
-  showCloseButton: PropTypes.bool
+ModalHeader.contextTypes = {
+  handleClose: PropTypes.func,
 };
 
 ModalHeader.displayName = 'ModalHeader';

--- a/src/lib/Popover/index.js
+++ b/src/lib/Popover/index.js
@@ -10,7 +10,6 @@ import { omit } from 'lodash';
  */
 
 class Popover extends React.Component {
-  static displayName = 'Popover';
 
   state = {
     isOpen: false,
@@ -243,6 +242,33 @@ class Popover extends React.Component {
   }
 }
 
+Popover.propTypes = {
+  /** @prop Children node that should be the popover trigger(this should be a stateful component) */
+  children: PropTypes.element.isRequired,
+  /** @prop Optional CSS class names which goes over popover container | '' */
+  className: PropTypes.string,
+  /** @prop The content that goes into the popover */
+  content: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
+  /** @prop The delay for popover on hover, click, focus (hide/show) | 0 */
+  delay: PropTypes.number,
+  /** @prop Boolean for whether the Anchor Toggles the Popover | true */
+  doesAnchorToggle: PropTypes.bool,
+  /** @prop The hide delay for popover on hover, click, focus | 0 */
+  hideDelay: PropTypes.number,
+  /** @prop The hover delay for checking whether we are still hovering before closing | 500 */
+  hoverDelay: PropTypes.number,
+  /** @prop Callback function that will execute on close | null */
+  onClose: PropTypes.func,
+  /** @prop Optional prop that controls overflow css style of EventOverlay | 'auto' */
+  overflowType: PropTypes.string,
+  /** @prop Event that will trigger popover appearance | 'MouseEnter' */
+  popoverTrigger: PropTypes.oneOf(['MouseEnter', 'Click', 'Focus']),
+   /** @prop Boolean for whether the Arrow should show | true */
+  showArrow: PropTypes.bool,
+  /** @prop The show delay for popover on hover, click, focus | 0 */
+  showDelay: PropTypes.number,
+};
+
 Popover.defaultProps = {
   className: '',
   delay: 0,
@@ -256,56 +282,7 @@ Popover.defaultProps = {
   showDelay: 0,
 };
 
-Popover.propTypes = {
-  /**
-   * this should be the popover trigger(this should be a stateful component)
-   */
-  children: PropTypes.element.isRequired,
-  /**
-   * css class names which goes over popover container
-   */
-  className: PropTypes.string,
-  /**
-   * the content that goes into the popover
-   */
-  content: PropTypes.oneOfType([PropTypes.element, PropTypes.node]).isRequired,
-  /**
-   * the delay for popover on hover, click, focus (hide/show)
-   */
-  delay: PropTypes.number,
-  /**
-   * Boolean for whether the Anchor Toggles the Popover
-   */
-  doesAnchorToggle: PropTypes.bool,
-  /**
-   * the hide delay for popover on hover, click, focus
-   */
-  hideDelay: PropTypes.number,
-  /**
-   * the hover delay for checking whether we are still hovering before closing
-   */
-  hoverDelay: PropTypes.number,
-  /**
-   * optional function that will execute on close
-   */
-  onClose: PropTypes.func,
-  /**
-   * optional prop that controls overflow css style of EventOverlay
-   */
-  overflowType: PropTypes.string,
-  /**
-   * Event that will trigger popover appearance
-   */
-  popoverTrigger: PropTypes.oneOf(['MouseEnter', 'Click', 'Focus']),
-   /**
-   * Boolean for whether the Arrow should show
-   */
-  showArrow: PropTypes.bool,
-  /**
-   * the show delay for popover on hover, click, focus
-   */
-  showDelay: PropTypes.number,
-};
+Popover.displayName = 'Popover';
 
 export default Popover;
 

--- a/src/lib/ProgressBar/index.js
+++ b/src/lib/ProgressBar/index.js
@@ -65,47 +65,31 @@ const ProgressBar = props => {
 };
 
 ProgressBar.propTypes = {
-  /**
-   * label string required
-   */
-  label: PropTypes.string.isRequired,
-  /**
-   * value number required
-   */
-  value: PropTypes.number.isRequired,
-  /**
-   * min number optional
-   */
-  min: PropTypes.number,
-  /**
-   * max number optional
-   */
-  max: PropTypes.number,
-  /**
-   * dyanmic bool optional
-   */
-  dynamic: PropTypes.bool,
-  /**
-   * color class optional will overwrite dynamic
-   */
+  /** @prop Color class optional that will overwrite dynamic | '' */
   color: PropTypes.string,
-  /**
-   * dyanmic number required
-   */
+  /** @prop Format of dyanmic number | 'fraction' */
   displayFormat: PropTypes.oneOf(['none', 'fraction', 'percentage']),
-  /**
-   * optional type prop type
-   */
+  /** @prop Determines if the ProgressBar is dynamic | false */
+  dynamic: PropTypes.bool,
+  /** @prop Label text */
+  label: PropTypes.string.isRequired,
+  /** @prop Maximum number for progressBar | 100 */
+  max: PropTypes.number,
+  /** @prop Minimum number for progressBar | 0 */
+  min: PropTypes.number,
+  /** @prop Type of ProgressBar | 'determinate' */
   type: PropTypes.oneOf(['determinate', 'indeterminate']),
+  /** @prop Number value */
+  value: PropTypes.number.isRequired,
 };
 
 ProgressBar.defaultProps = {
-  min: 0,
-  max: 100,
-  type: 'determinate',
-  dynamic: false,
-  displayFormat: 'fraction',
   color: '',
+  displayFormat: 'fraction',
+  dynamic: false,
+  max: 100,
+  min: 0,
+  type: 'determinate',
 };
 
 ProgressBar.displayName = 'ProgressBar';

--- a/src/lib/Radio/index.js
+++ b/src/lib/Radio/index.js
@@ -52,67 +52,44 @@ const Radio = props => {
 };
 
 Radio.propTypes = {
-  /**
-   * optional nextLevel prop type
-   */
-  nestedLevel: PropTypes.number,
-  /**
-   * optional className prop type
-   */
-  className: PropTypes.string,
-  /**
-   * optional disabled prop type
-   */
-  disabled: PropTypes.bool,
-  /**
-   * optional required prop type
-   */
-  required: PropTypes.bool,
-  /**
-   * optional checked prop type
-   */
+  /** @prop Boolean for whether the Radio button is checked | false */
   checked: PropTypes.bool,
-  /**
-   * optional name prop type
-   */
-  name: PropTypes.string,
-  /**
-   * optional label prop type
-   */
-  label: PropTypes.string,
-  /**
-   * optional value prop type
-   */
-  value: PropTypes.string,
-  /**
-   * optional ref prop type
-   */
-  inputRef: PropTypes.func,
-  /**
-   * Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing.
-   */
-  htmlId: PropTypes.string.isRequired,
-  /**
-   * optional onChange prop type
-   */
-  onChange: PropTypes.func,
-  /**
-   * Child component to display next to the input
-   */
+  /** @prop Children nodes to render insdie Radio component | null */
   children: PropTypes.node,
+  /** @prop Optional CSS class name | '' */
+  className: PropTypes.string,
+  /** @prop Sets the attribute disabled to the Radio | false */
+  disabled: PropTypes.bool,
+  /** @prop Unique HTML ID used for tying label to HTML input for automated testing */
+  htmlId: PropTypes.string.isRequired,
+  /** @prop Optional ref attribute for Radio input element | null */
+  inputRef: PropTypes.func,
+  /** @prop Radio label text | '' */
+  label: PropTypes.string,
+  /** @prop Radio name string | '' */
+  name: PropTypes.string,
+  /** @prop Set the level of nested Radios | 0 */
+  nestedLevel: PropTypes.number,
+  /** @prop Callback function invoked when user makes a change with the Radio button | null */
+  onChange: PropTypes.func,
+  /** @prop Requires the user to populate the Radio input | false */
+  required: PropTypes.bool,
+  /** @prop String value that corresponds with Radio button | '' */
+  value: PropTypes.string,
 };
 
 Radio.defaultProps = {
-  nestedLevel: 0,
+  checked: false,
+  children: null,
   className: '',
   disabled: false,
-  required: false,
-  checked: false,
-  name: '',
-  value: '',
-  label: '',
   inputRef: null,
+  label: '',
+  name: '',
+  nestedLevel: 0,
   onChange: null,
+  required: false,
+  value: '',
 };
 
 Radio.displayName = 'Radio';

--- a/src/lib/RadioGroup/index.js
+++ b/src/lib/RadioGroup/index.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
  */
 
 class RadioGroup extends React.Component {
-  static displayName = 'RadioGroup';
 
   state = {
     values: [],
@@ -58,35 +57,29 @@ class RadioGroup extends React.Component {
 }
 
 RadioGroup.propTypes = {
-  /**
-   * optional children prop type
-   */
+  /** @prop Children nodes to render inside RadioGroup | null */
   children: PropTypes.node,
-  /**
-   * Callback fired when a button is pressed, depending on whether the `type`
-   * is `'radio'` or `'checkbox'`, `onChange` will be called with the value or
-   * array of active values
-   *
+  /** @prop An HTML `<input>` name for each child button | '' */
+  name: PropTypes.string,
+  /** 
+   * @prop Callback function called with value or array of values when invoked by user making a change with the RadioGroup | () => {}
    * @controllable values
-   */
+  */
   onChange: PropTypes.func,
   /**
-   * An array of values, of the active (pressed) buttons
-   *
+   * @prop Array of values, of the active (pressed) buttons | []
    * @controllable onChange
-   */
+  */
   values: PropTypes.array,
-  /**
-   * An HTML `<input>` name for each child button.
-   *
-   */
-  name: PropTypes.string,
 };
 
 RadioGroup.defaultProps = {
-  values: [],
-  onChange: () => {},
+  children: null,
   name: '',
+  onChange: () => {},
+  values: [],
 };
+
+RadioGroup.displayName = 'RadioGroup';
 
 export default RadioGroup;

--- a/src/lib/SearchInput/index.js
+++ b/src/lib/SearchInput/index.js
@@ -33,16 +33,16 @@ const SearchInput = props => {
   );
 };
 
-SearchInput.displayName = 'SearchInput';
+SearchInput.propTypes = {
+  /** @prop Style of search input normal or pill | 'normal' */
+  type: PropTypes.oneOf(['normal', 'pill'])
+};
 
 SearchInput.defaultProps = {
   type: 'normal'
 };
 
-SearchInput.propTypes = {
-  /** style of search input normal or pill */
-  type: PropTypes.oneOf(['normal', 'pill'])
-};
+SearchInput.displayName = 'SearchInput';
 
 export default SearchInput;
 

--- a/src/lib/Select/index.js
+++ b/src/lib/Select/index.js
@@ -21,7 +21,6 @@ import {
 } from 'lodash';
 
 class Select extends React.Component {
-  static displayName = 'Select';
 
   state = {
     isOpen: false,
@@ -184,19 +183,27 @@ class Select extends React.Component {
 }
 
 Select.propTypes = {
+  /** @prop Children nodes to render inside Select component | null */
   children: PropTypes.node,
+  /** @prop Optional CSS class name | '' */
   className: PropTypes.string,
+  /** @prop Set the default selected option | '' */
   defaultValue: PropTypes.string,
+  /** @prop Set ID for Select Component | null */
   id: PropTypes.string,
+  /** @prop Sets the Select EventOverlay to be dynamic | true */
   isDynamic: PropTypes.bool,
+  /** @prop Optional prop to know if multiple Select children can be active | false */
   isMulti: PropTypes.bool,
+  /** @prop Callback function invoked when user selects an item | null */
   onSelect: PropTypes.func,
+  /** @prop Sets the EventOverlay props | null */
   overlayProps: PropTypes.shape({}),
 };
 
 Select.defaultProps = {
-  className: '',
   children: null,
+  className: '',
   defaultValue: '',
   id: null,
   isDynamic: true,
@@ -204,6 +211,8 @@ Select.defaultProps = {
   onSelect: null,
   overlayProps: null,
 };
+
+Select.displayName = 'Select';
 
 export default Select;
 

--- a/src/lib/SelectOption/index.js
+++ b/src/lib/SelectOption/index.js
@@ -15,7 +15,6 @@ import {
  */
 
 class SelectOption extends React.Component {
-  static displayName = 'SelectOption';
 
   state = {
     id: this.props.id || uniqueId('cui-select-option-'),
@@ -71,6 +70,25 @@ class SelectOption extends React.Component {
   }
 }
 
+SelectOption.propTypes = {
+  /** @prop SelectOption Boolean that describes active state | false */
+  active: PropTypes.bool,
+  /** @prop Children nodes to render inside SelectOption | null */
+  children: PropTypes.node,
+  /** @prop Optional HTML Class Name for ListItem | '' */
+  className: PropTypes.string,
+  /** @prop SelectOption ID | '' */
+  id: PropTypes.string,
+  /** @prop Optional prop to know if multiple SelectOptions can be active | false */
+  isMulti: PropTypes.bool,
+  /** @prop SelectOption label text | '' */
+  label: PropTypes.string,
+  /** @prop ListItem Title | '' */
+  title: PropTypes.string,
+  /** @prop SelectOption value | '' */
+  value: PropTypes.string,
+};
+
 SelectOption.defaultProps = {
   active: false,
   children: null,
@@ -82,23 +100,6 @@ SelectOption.defaultProps = {
   value:'',
 };
 
-SelectOption.propTypes = {
-  /** SelectOption Boolean that describes active state */
-  active: PropTypes.bool,
-  /** SelectOption Children */
-  children: PropTypes.node,
-  /** HTML Class for ListItem */
-  className: PropTypes.string,
-  /** SelectOption id */
-  id: PropTypes.string,
-  /** SelectOption Boolean that modifies adds checkboxes */
-  isMulti: PropTypes.bool,
-  /** SelectOption string alternative to children nodes */
-  label: PropTypes.string,
-  /** ListItem Title */
-  title: PropTypes.string,
-  /** Value  */
-  value: PropTypes.string,
-};
+SelectOption.displayName = 'SelectOption';
 
 export default SelectOption;

--- a/src/lib/SideNav/index.js
+++ b/src/lib/SideNav/index.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import { Icon } from '@collab-ui/react';
 
 class SideNav extends React.Component {
-  static displayName = 'SideNav';
 
   state = {
     expanded: this.props.expanded
@@ -48,40 +47,30 @@ class SideNav extends React.Component {
 }
 
 SideNav.propTypes = {
-  /**
-   * Children Nodes to Render inside side navigation
-   */
+  /** @prop Children nodes to Render inside side navigation | null */
   children: PropTypes.node,
-  /**
-   * Title for the side navigation
-   */
-  navSectionTitle: PropTypes.string,
-  /**
-   * Check whether the navigation is the top level
-   */
-  topMenu: PropTypes.bool,
-  /**
-   * Make the navigation expandable
-   */
+  /** @prop Optional CSS class string | '' */
+  className: PropTypes.string,
+  /** @prop Set to make the navigation expandable | false */
   expandable: PropTypes.bool,
-  /**
-   * Set navigation expanded or collapsed
-   */
+  /** @prop Set navigation expanded or collapsed | false */
   expanded: PropTypes.bool,
-   /**
-   * optional customized css class string
-   */
-  className: PropTypes.string
+  /** @prop Title for the side navigation | '' */
+  navSectionTitle: PropTypes.string,
+  /** @prop Sets side navigation as the top level | false */
+  topMenu: PropTypes.bool,
 };
 
 SideNav.defaultProps = {
   children: null,
-  navSectionTitle: '',
-  topMenu: false,
+  className: '',
   expandable: false,
   expanded: false,
-  className: ''
+  navSectionTitle: '',
+  topMenu: false,
 };
+
+SideNav.displayName = 'SideNav';
 
 export default SideNav;
 

--- a/src/lib/Slider/SliderPointer/index.js
+++ b/src/lib/Slider/SliderPointer/index.js
@@ -99,7 +99,9 @@ class SliderPointer extends React.PureComponent {
 }
 
 SliderPointer.propTypes = {
+  /** @prop Set Slider Pointer's position | 0 */
   position: PropTypes.number,
+  /** @prop Callback function invoked when user moves the Slider Pointer | null */
   onMove: PropTypes.func,
 };
 
@@ -107,5 +109,7 @@ SliderPointer.defaultProps = {
   position: 0,
   onMove: null,
 };
+
+SliderPointer.displayName = 'SliderPointer';
 
 export default SliderPointer;

--- a/src/lib/Slider/index.js
+++ b/src/lib/Slider/index.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import SliderPointer from '@collab-ui/react/Slider/SliderPointer';
 
 class Slider extends React.Component {
-  static displayName = 'Slider';
 
   state = {
     sliderLow: this.props.value.low || this.props.min,
@@ -189,27 +188,37 @@ class Slider extends React.Component {
 }
 
 Slider.propTypes = {
-  className: PropTypes.string,
+  /** @prop Determines if minimum pointer can cross over maximum pointer | false */
   canCross: PropTypes.bool,
+  /** @prop Optional CSS class string | '' */
+  className: PropTypes.string,
+  /** @prop Set the attribute disabled to Slider | false */
   disabled: PropTypes.bool,
+  /** @prop Set the initial maximum value */
   max: PropTypes.number.isRequired,
+  /** @prop Set the initial minimum value | 0 */
   min: PropTypes.number,
+  /** @prop Callback function invoked by user when change a pointer position | null */
   onChange: PropTypes.func,
+  /** @prop Set visual step measurement | 1 */
   step: PropTypes.number,
+  /** @prop Set increment of x-axis labels | 0 */
   tick: PropTypes.number,
+  /** @prop Function to compute layout of Slider | null */
   translateFn: PropTypes.func,
+  /** @prop Set either maximum pointer value or a combination of high and low pointer values | 0 */
   value: PropTypes.oneOfType([
     PropTypes.shape({
+      high: PropTypes.number.isRequired,
       low: PropTypes.number.isRequired,
-      high: PropTypes.number.isRequired
     }),
     PropTypes.number
   ])
 };
 
 Slider.defaultProps = {
-  className: '',
   canCross: false,
+  className: '',
   disabled: false,
   min: 0,
   onChange: null,
@@ -218,6 +227,8 @@ Slider.defaultProps = {
   translateFn: null,
   value: 0
 };
+
+Slider.displayName = 'Slider';
 
 export default Slider;
 

--- a/src/lib/SocialList/index.js
+++ b/src/lib/SocialList/index.js
@@ -8,7 +8,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class SocialList extends React.Component {
-  static displayName = 'SocialList';
 
   render() {
     const { children } = this.props;
@@ -18,12 +17,15 @@ class SocialList extends React.Component {
 }
 
 SocialList.propTypes = {
+  /** @prop Children nodes to render inside SocialList | null */
   children: PropTypes.node
 };
 
 SocialList.defaultProps = {
   children: null
 };
+
+SocialList.displayName = 'SocialList';
 
 export default SocialList;
 

--- a/src/lib/SpaceListItem/index.js
+++ b/src/lib/SpaceListItem/index.js
@@ -15,7 +15,6 @@ import {
  */
 
 class SpaceListItem extends React.PureComponent {
-  static displayName = 'SpaceListItem';
 
   state = {
     id: this.props.id || uniqueId('cui-space-list-item-')
@@ -227,75 +226,79 @@ class SpaceListItem extends React.PureComponent {
   }
 }
 
+SpaceListItem.propTypes = {
+  /** @prop SpaceListItem Attachment Array | null */
+  attachments: PropTypes.arrayOf(PropTypes.node),
+  /** @prop Children nodes to render for left section | null */
+  childrenLeft: PropTypes.node,
+  /** @prop Children nodes to render for right section | null */
+  childrenRight: PropTypes.node,
+  /** @prop Optional HTML class string | '' */
+  className: PropTypes.string,
+  /** @prop ListItem header node */
+  header: PropTypes.node.isRequired,
+  /** @prop Secondary header for center section | '' */
+  headerSecondary: PropTypes.string,
+  /** @prop Highlight Color for Regex | '' */
+  highlightColor: PropTypes.string,
+  /** @prop HTML ID for SpaceListItem | '' */
+  id: PropTypes.string,
+  /** @prop Determines if SpaceListItem's Alert is on | false */
+  isAlertOn: PropTypes.bool,
+  /** @prop Determines if SpaceListItem is Bolded | false */
+  isBold: PropTypes.bool,
+  /** @prop Determines if SpaceListItem decrypting | false */
+  isDecrypting: PropTypes.bool,
+  /** @prop Determines if SpaceListItem has been mentioned | false */
+  isMentioned: PropTypes.bool,
+  /** @prop Determines if SpaceListItem has been muted | false */
+  isMuted: PropTypes.bool,
+  /** @prop Determines if SpaceListItem is an Overview item | false */
+  isOverview: PropTypes.bool,
+  /** @prop Determines if SpaceListItem is unread | false */
+  isUnread: PropTypes.bool,
+  /** @prop Children node for result right section | null */
+  resultRight: PropTypes.node,
+  /** @prop Word used for search | '' */
+  searchTerm: PropTypes.string,
+  /** @prop SpaceListItem subheader node | ''s */
+  subheader: PropTypes.node,
+  /** @prop SpaceListItem title | '' */
+  title: PropTypes.string,
+  /** @prop SpaceListItem type | '' */
+  type: PropTypes.oneOf([
+    '',
+    'filter',
+    'filter-search',
+    'filter-summary',
+    'flag',
+    'search',
+  ])
+};
+
 SpaceListItem.defaultProps = {
   attachments: null,
-  className: '',
   childrenLeft: null,
   childrenRight: null,
+  className: '',
   headerSecondary: '',
   highlightColor: '',
   id: '',
   isAlertOn: false,
   isBold: false,
   isDecrypting: false,
-  isOverview: false,
   isMentioned: false,
   isMuted: false,
+  isOverview: false,
   isUnread: false,
   resultRight: null,
+  searchTerm: '',
   subheader: '',
+  title: '',
   type: ''
 };
 
-SpaceListItem.propTypes = {
-  /** ListItem Attachment Array */
-  attachments: PropTypes.arrayOf(PropTypes.node),
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** Children for left section */
-  childrenLeft: PropTypes.node,
-  /** Children for right section */
-  childrenRight: PropTypes.node,
-  /** ListItem header */
-  header: PropTypes.node.isRequired,
-  /** Secondary Header for center Section */
-  headerSecondary: PropTypes.string,
-  /** Highlight Color for Regex */
-  highlightColor: PropTypes.string,
-  /** HTML ID for associated input */
-  id: PropTypes.string,
-  /** SpaceListItem Boolean */
-  isAlertOn: PropTypes.bool,
-  /** SpaceListItem Boolean */
-  isBold: PropTypes.bool,
-  /** SpaceListItem Boolean */
-  isDecrypting: PropTypes.bool,
-  /** SpaceListItem Boolean */
-  isOverview: PropTypes.bool,
-  /** SpaceListItem Boolean */
-  isMentioned: PropTypes.bool,
-  /** SpaceListItem Boolean */
-  isUnread: PropTypes.bool,
-  /** SpaceListItem Boolean */
-  isMuted: PropTypes.bool,
-  /** Children for result right section */
-  resultRight: PropTypes.node,
-  /** ListItem searchTerm */
-  searchTerm: PropTypes.string,
-  /** ListItem subheader */
-  subheader: PropTypes.node,
-  /** ListItem title */
-  title: PropTypes.string,
-  /** ListItem type */
-  type: PropTypes.oneOf([
-    '',
-    'search',
-    'filter-summary',
-    'filter',
-    'flag',
-    'filter-search'
-  ])
-};
+SpaceListItem.displayName = 'SpaceListItem';
 
 export default SpaceListItem;
 

--- a/src/lib/SpaceListMeeting/index.js
+++ b/src/lib/SpaceListMeeting/index.js
@@ -18,7 +18,6 @@ import { omit, uniqueId } from 'lodash';
  */
 
 class SpaceListMeeting extends React.PureComponent {
-  static displayName = 'SpaceListMeeting';
 
   state = {
     id: this.props.id || uniqueId('cui-space-list-meeting-'),
@@ -161,6 +160,40 @@ class SpaceListMeeting extends React.PureComponent {
   }
 }
 
+SpaceListMeeting.propTypes = {
+  /** @prop Array of Attendee's Data | [] */
+  attendees: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      alt: PropTypes.string,
+      src: PropTypes.string,
+      node: PropTypes.element
+    })
+  ),
+  /** @prop Label string for button | '' */
+  buttonLabel: PropTypes.string,
+  /** @prop Callback function invoked when user clicks on button | null */
+  buttonOnClick: PropTypes.func,
+  /** @prop Children nodes to render for left section | null */
+  childrenLeft: PropTypes.node,
+  /** @prop Children nodes to render for right section | null */
+  childrenRight: PropTypes.node,
+  /** @prop Optional HTML Class string | '' */
+  className: PropTypes.string,
+  /** @prop ListItem header text | '' */
+  header: PropTypes.node.isRequired,
+  /** @prop HTML ID for SpaceListMeeting | '' */
+  id: PropTypes.string,
+  /** @prop Determines if SpaceListMeeting is Bolded | false */
+  isBold: PropTypes.bool,
+  /** @prop Set the SpaceListMeeting type | '' */
+  meetingType: PropTypes.oneOf(['', 'group', 'number', 'device']),
+  /** @prop SpaceListMeeting sub header node | '' */
+  subheader: PropTypes.node,
+  /** @prop SpaceListMeeting title | '' */
+  title: PropTypes.string
+};
+
 SpaceListMeeting.defaultProps = {
   attendees: [],
   buttonLabel: '',
@@ -170,43 +203,12 @@ SpaceListMeeting.defaultProps = {
   className: '',
   id: '',
   isBold: false,
+  meetingType: '',
   subheader: '',
   title: ''
 };
 
-SpaceListMeeting.propTypes = {
-  /** Array for Attendees */
-  attendees: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      alt: PropTypes.string,
-      src: PropTypes.string,
-      node: PropTypes.element
-    })
-  ),
-  /** String for button */
-  buttonLabel: PropTypes.string,
-  /** OnClick for button */
-  buttonOnClick: PropTypes.func,
-  /** Children for left section */
-  childrenLeft: PropTypes.node,
-  /** Children for right section */
-  childrenRight: PropTypes.node,
-  /** HTML Class for associated input */
-  className: PropTypes.string,
-  /** ListItem header */
-  header: PropTypes.node.isRequired,
-  /** HTML ID for associated input */
-  id: PropTypes.string,
-  /** Header Boolean */
-  isBold: PropTypes.bool,
-  /** HTML Class for associated input */
-  meetingType: PropTypes.oneOf(['', 'group', 'number', 'device']),
-  /** ListItem header */
-  subheader: PropTypes.node,
-  /** ListItem title */
-  title: PropTypes.string
-};
+SpaceListMeeting.displayName = 'SpaceListMeeting';
 
 export default SpaceListMeeting;
 

--- a/src/lib/Spinner/index.js
+++ b/src/lib/Spinner/index.js
@@ -71,29 +71,17 @@ const Spinner = props => {
 };
 
 Spinner.propTypes = {
-  /**
-   * css class names
-   */
+  /** @prop Optional CSS class names | '' */
   className: PropTypes.string,
-  /**
-   * color
-   */
+  /** @prop Set Spinner color | '' */
   color: PropTypes.string,
-  /**
-   * percentage value to show on progress
-   */
+  /** @prop Show percentage value for progress on Spinner | null */
   percentage: PropTypes.number,
-  /**
-   * show the check mark if percentage 100
-   */
+  /** @prop Show the check mark if percentage 100 | false */
   showCheck: PropTypes.bool,
-  /**
-   * show the number value for progress
-   */
+  /** @prop Show the number value for progress on Spinner | false */
   showPercentage: PropTypes.bool,
-  /**
-   * size
-   */
+  /** @prop Spinner size | 36 */
   size: PropTypes.oneOf([16, 20, 28, 36]),
 };
 

--- a/src/lib/SubMenu/index.js
+++ b/src/lib/SubMenu/index.js
@@ -8,7 +8,6 @@ import {
 } from '@collab-ui/react/';
 
 class SubMenu extends React.Component {
-  static displayName = 'SubMenu';
 
   state = {
     anchorRef: null,
@@ -141,22 +140,28 @@ class SubMenu extends React.Component {
   }
 }
 
-SubMenu.contextTypes = {
-  handleClick: PropTypes.func,
-  handleKeyDown: PropTypes.func,
-};
-
 SubMenu.propTypes = {
+  /** @prop Children nodes to render inside SubMenu | null */
   children: PropTypes.node,
+  /** @prop Optional CSS class names | '' */
   className: PropTypes.string,
+  /** @prop SubMenu content element | null */
   content: PropTypes.element,
-  customNode: PropTypes.node, 
+  /** @prop SubMenu custom Node | null */
+  customNode: PropTypes.node,
+  /** @prop Index of SubMenu | [] */
   index: PropTypes.array,
+  /** @prop Determines if the SubMenu is the header | false */
   isHeader: PropTypes.bool,
+  /** @prop Determines if the SubMenu is Open | false */
   isOpen: PropTypes.bool,
+  /** @prop Boolean whether to keep the SubMenu open | false */
   keepMenuOpen: PropTypes.bool,
+  /** @prop SubMenu label string | '' */
   label: PropTypes.string,
+  /** @prop Callback function invoked when user clicks the SubMenu | null */
   onClick: PropTypes.func,
+  /** @prop Initial selected value within SubMenu | '' */
   selectedValue: PropTypes.string,
 };
 
@@ -165,6 +170,7 @@ SubMenu.defaultProps = {
   className: '',
   content: null,
   customNode: null,
+  index: [],
   isHeader: false,
   isOpen: false,
   keepMenuOpen: false,
@@ -172,5 +178,12 @@ SubMenu.defaultProps = {
   onClick: null,
   selectedValue: '',
 };
+
+SubMenu.contextTypes = {
+  handleClick: PropTypes.func,
+  handleKeyDown: PropTypes.func,
+};
+
+SubMenu.displayName = 'SubMenu';
 
 export default SubMenu;

--- a/src/lib/Tab/index.js
+++ b/src/lib/Tab/index.js
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
  */
 
 class Tab extends React.PureComponent {
-  static displayName = 'Tab';
 
   componentDidUpdate() {
     this.props.focus && this.tabLink.focus();
@@ -58,47 +57,37 @@ class Tab extends React.PureComponent {
 /* eslint-enable */
 
 Tab.propTypes = {
-  /**
-   * required function for onClick events
-   */
-  onPress: PropTypes.func,
-  /**
-   * required function for keyPress events
-   */
-  onKeyDown: PropTypes.func,
-  /**
-   * required heading prop type
-   */
-  heading: PropTypes.string.isRequired,
-  /**
-   * optional active prop type
-   */
+  /** @prop Set Tab with an active state | false */
   active: PropTypes.bool,
-  /** focus prop for whether focus should change */
-  focus: PropTypes.bool,
-  /**
-   * optional role prop type
-   */
-  role: PropTypes.string,
-  /**
-   * optional className prop
-   */
+  /** @prop Optional CSS class name */
   className: PropTypes.string,
-  /**
-   * optional disabled prop
-   */
+  /** @prop Sets the attribute disabled to the Tab | false */
   disabled: PropTypes.bool,
+  /** @prop Specifies if Tab should automatically get focus when page loads | false */
+  focus: PropTypes.bool,
+  /** @prop Tab Heading Text */
+  heading: PropTypes.string.isRequired,
+  /** @prop Currently unused prop myKey | 0 */
+  myKey: PropTypes.number,
+  /** @prop Callback function invoked when user presses a key | null */
+  onKeyDown: PropTypes.func,
+  /** @prop Callback function invoked when user presses on the Tab | null */
+  onPress: PropTypes.func,
+  /** @prop Tab's anchor role type | 'tab' */
+  role: PropTypes.string,
 };
 
 Tab.defaultProps = {
   active: false,
-  myKey: 0,
-  onPress: null,
-  onKeyPress: null,
-  role: 'tab',
-  focus: false,
   className: '',
-  disabled: false
+  disabled: false,
+  focus: false,
+  myKey: 0,
+  onKeyDown: null,
+  onPress: null,
+  role: 'tab',
 };
+
+Tab.displayName = 'Tab';
 
 export default Tab;

--- a/src/lib/TabContent/index.js
+++ b/src/lib/TabContent/index.js
@@ -21,14 +21,15 @@ const TabContent = props => {
 };
 
 TabContent.propTypes = {
-  /**
-   * optional children prop type
-   */
+  /** @prop Determines the initial active index | null */
   activeIndex: PropTypes.number,
-  /**
-   * optional children prop type
-   */
+  /** @prop Children nodes to render inside TabContent | null */
   children: PropTypes.node,
+};
+
+TabContent.defaultProps = {
+  activeIndex: null,
+  children: null,
 };
 
 TabContent.displayName = 'TabContent';

--- a/src/lib/TabHeader/index.js
+++ b/src/lib/TabHeader/index.js
@@ -21,13 +21,9 @@ const TabHeader = props => {
 };
 
 TabHeader.propTypes = {
-  /**
-   * required heading prop type
-   */
+  /** @prop TabHeader text */
   heading: PropTypes.string.isRequired,
-  /**
-   * optional subHeading prop type
-   */
+  /** @prop Subheader text | '' */
   subHeading: PropTypes.string,
 };
 

--- a/src/lib/TabList/index.js
+++ b/src/lib/TabList/index.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
  * @constructor
  */
 class TabList extends React.Component {
-  static displayName = 'TabList';
 
   componentDidMount() {
     this.determineInitialFocus();
@@ -192,43 +191,32 @@ class TabList extends React.Component {
   }
 }
 
-TabList.contextTypes = {
-  /**
-   * optional active prop type
-   */
-  onFocus: PropTypes.func,
-  /**
-   * optional active prop type
-   */
-  focus: PropTypes.number,
-  /**
-   * optional active prop type
-   */
-  activeIndex: PropTypes.number,
-  /**
-   * optional active prop type
-   */
-  onActivate: PropTypes.func,
-};
-
 TabList.propTypes = {
-  /**
-   * optional children prop type
-   */
+  /** @prop Children nodes to render inside TabList | null */
   children: PropTypes.node,
   /**
-   * ARIA role for the Nav, in the context of a TabContainer, the default will
+   * @prop ARIA role for the Nav, in the context of a TabContainer, the default will
    * be set to "tablist", but can be overridden by the Nav when set explicitly.
    *
    * When the role is set to "tablist" NavItem focus is managed according to
    * the ARIA authoring practices for tabs:
-   * https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#tabpanel
+   * https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#tabpanel | 'TabList'
    */
   role: PropTypes.string
 };
 
 TabList.defaultProps = {
+  children: null,
   role: 'tablist'
 };
+
+TabList.contextTypes = {
+  onFocus: PropTypes.func,
+  focus: PropTypes.number,
+  activeIndex: PropTypes.number,
+  onActivate: PropTypes.func,
+};
+
+TabList.displayName = 'TabList';
 
 export default TabList;

--- a/src/lib/TabPane/index.js
+++ b/src/lib/TabPane/index.js
@@ -18,18 +18,15 @@ const TabPane = props => {
 };
 
 TabPane.propTypes = {
-  /**
-   * optional children prop type
-   */
-  children: PropTypes.node,
-  /**
-   * optional active prop type
-   */
+  /** @prop Determines if TabPane is active | false */
   active: PropTypes.bool,
+  /** @prop Children nodes to render inside TabPane | null */
+  children: PropTypes.node,
 };
 
 TabPane.defaultProps = {
   active: false,
+  children: null,
 };
 
 TabPane.displayName = 'TabPane';

--- a/src/lib/Tabs/index.js
+++ b/src/lib/Tabs/index.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
  */
 
 class Tabs extends React.Component {
-  static displayName = 'Tabs';
 
   state = {
     activeIndex: 0,
@@ -110,6 +109,32 @@ class Tabs extends React.Component {
   }
 }
 
+Tabs.propTypes = {
+  /** @prop Determines if Tab is active | false */
+  active: PropTypes.bool,
+  /** @prop Children nodes of Tab and TabContent are required */
+  children: PropTypes.node.isRequired,
+  /** @prop Optional CSS class name | '' */
+  className: PropTypes.string,
+  /** @prop Set the index of the focused Tab | 0 */
+  focus: PropTypes.number,
+  /** @prop Determines if the Tabs are in a justified layout | false */
+  justified: PropTypes.bool,
+  /** @prop Callback function invoked when user selects a tab | null */
+  onSelect: PropTypes.func,
+  /** @prop Type of Tabs | 'pills' */
+  tabType: PropTypes.oneOf(['pills']),
+};
+
+Tabs.defaultProps = {
+  active: false,
+  className: '',
+  focus: 0,
+  justified: false,
+  onSelect: null,
+  tabType: 'pills',
+};
+
 Tabs.childContextTypes = {
   focus: PropTypes.number,
   activeIndex: PropTypes.number,
@@ -117,40 +142,7 @@ Tabs.childContextTypes = {
   onFocus: PropTypes.func,
 };
 
-Tabs.propTypes = {
-  /**
-   * Children of Tab and TabContent required to work
-   */
-  children: PropTypes.node.isRequired,
-  /**
-   * optional className prop type
-   */
-  className: PropTypes.string,
-  /**
-   * optional onSelect prop type defaults to navigating to other panes
-   */
-  onSelect: PropTypes.func,
-  /**
-   * optional tabType prop type defaults to horizontal
-   */
-  tabType: PropTypes.oneOf(['pills']),
-  /**
-   * optional justified prop type
-   */
-  justified: PropTypes.bool,
-  /**
-   * optional focusIndex prop
-   */
-  focus: PropTypes.number
-};
-
-Tabs.defaultProps = {
-  active: false,
-  tabType: 'pills',
-  className: '',
-  justified: false,
-  focus: 0
-};
+Tabs.displayName = 'Tabs';
 
 export default Tabs;
 

--- a/src/lib/TimePicker/TimeSelector/index.js
+++ b/src/lib/TimePicker/TimeSelector/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class TimeSelector extends React.Component {
-  static displayName = 'TimeSelector';
   
   state = {
     value: this.props.value,
@@ -105,9 +104,30 @@ class TimeSelector extends React.Component {
   }
 }
 
+TimeSelector.propTypes = {
+  /** @prop Ref attribute for TimeSelector input element | null */
+  inputRef: PropTypes.func,
+  /** @prop Choose to use military time | false */
+  militaryTime: PropTypes.bool,
+  /** @prop Callback function invoked when user presses down | null  */
+  onDownClick: PropTypes.func,
+  /** @prop Callback function invoked when user presses a key | null  */
+  onKeyDown: PropTypes.func,
+  /** @prop Callback function invoked when user releases a click | null  */
+  onUpClick: PropTypes.func,
+  /** @prop Callback function invoked when user wheels the mouse | null */
+  onWheel: PropTypes.func,
+  /** @prop Set the type for the Input element | 'text' */
+  type: PropTypes.string,
+  /** @prop Set the unit of time | '' */
+  unit: PropTypes.string,
+  /** @prop Set the value of the Input element | '' */
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+};
+
 TimeSelector.defaultProps = {
   inputRef: null,
-  miltaryTime: false,
+  militaryTime: false,
   onDownClick: null,
   onKeyDown: null,
   onUpClick: null,
@@ -117,16 +137,6 @@ TimeSelector.defaultProps = {
   value: '',
 };
 
-TimeSelector.propTypes = {
-  inputRef: PropTypes.func,
-  militaryTime: PropTypes.bool,
-  onDownClick: PropTypes.func,
-  onKeyDown: PropTypes.func,
-  onUpClick: PropTypes.func,
-  onWheel: PropTypes.func,
-  type: PropTypes.string,
-  unit: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-};
+TimeSelector.displayName = 'TimeSelector';
 
 export default TimeSelector;

--- a/src/lib/TimePicker/TimepickerDropdown/index.js
+++ b/src/lib/TimePicker/TimepickerDropdown/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class TimepickerDropdown extends React.PureComponent {
-  static displayName = 'TimepickerDropdown';
 
   render() {
     const { children } = this.props;
@@ -23,13 +22,15 @@ class TimepickerDropdown extends React.PureComponent {
   }
 }
 
+TimepickerDropdown.propTypes = {
+  /** @prop Children node to render within TimePickerDropdown | null */
+  children: PropTypes.node
+};
+
 TimepickerDropdown.defaultProps = {
   children: null
 };
 
-TimepickerDropdown.propTypes = {
-  /** Child component to display within Dropdown */
-  children: PropTypes.node
-};
+TimepickerDropdown.displayName = 'TimepickerDropdown';
 
 export default TimepickerDropdown;

--- a/src/lib/TimePicker/index.js
+++ b/src/lib/TimePicker/index.js
@@ -17,7 +17,6 @@ import {
 } from '@collab-ui/react';
 
 class TimePicker extends React.Component {
-  static displayName = 'TimePicker';
 
   state = {
     inputId: this.props.inputId || uniqueId('cui-timepicker__input-'),
@@ -239,11 +238,17 @@ class TimePicker extends React.Component {
 }
 
 TimePicker.propTypes = {
+  /** @prop Optional CSS class name | '' */
   className: PropTypes.string,
+  /** @prop Set Input element ID | '' */
   inputId: PropTypes.string,
+  /** @prop Choose to use military time | false */
   militaryTime: PropTypes.bool,
+  /** @prop Determine the minute interval | 1 */
   minuteInterval: PropTypes.oneOf([1, 5, 15, 30, 60]),
+  /** @prop Callback function invoked when user makes a change | null */
   onChange: PropTypes.func,
+  /** @prop Set the initial selected time | null */
   selectedTime: PropTypes.instanceOf(Date),
 };
 
@@ -255,6 +260,8 @@ TimePicker.defaultProps = {
   onChange: null,
   selectedTime: null,
 };
+
+TimePicker.displayName = 'TimePicker';
 
 export default TimePicker;
 

--- a/src/lib/ToggleSwitch/index.js
+++ b/src/lib/ToggleSwitch/index.js
@@ -8,7 +8,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class ToggleSwitch extends React.PureComponent {
-  static displayName = 'ToggleSwitch';
 
   state = { 
     isToggleOn: this.props.checked
@@ -64,50 +63,35 @@ class ToggleSwitch extends React.PureComponent {
 }
 
 ToggleSwitch.propTypes = {
-  /**
-   * @prop disabled | Set the toggle switch to disabled | false
-   */
-  disabled: PropTypes.bool,
-  /**
-   * @prop checked | Set the toggle switch to checked | false
-   */
+  /** @prop Set the toggle switch to checked | false */
   checked: PropTypes.bool,
-  /**
-   * @prop name | Sets the name of the toggle switch | ''
-   */
-  name: PropTypes.string,
-  /**
-   * @prop label | Sets the label string for the toggle switch | ''
-   */
-  label: PropTypes.string.isRequired,
-  /**
-   * @prop value | Sets the value of the toggle switch | ''
-   */
-  value: PropTypes.string,
-  /**
-   * @prop className | Sets the className for the toggle switch | ''
-   */
+  /** @prop Sets the className for the toggle switch | '' */
   className: PropTypes.string,
-  /**
-   * @prop htmlId | Unique HTML ID. Used for tying label to HTML input. Handy hook for automated testing.
-   */
+  /** @prop Set the toggle switch to disabled | false */
+  disabled: PropTypes.bool,
+  /** @prop Unique HTML ID used for tying label to HTML input for automated testing */
   htmlId: PropTypes.string.isRequired,
-  /**
-   * @prop onChange | Sets the callback function to call when state is changed | null
-   */
+  /** @prop Sets the label string for the toggle switch | '' */
+  label: PropTypes.string.isRequired,
+  /** @prop Sets the name of the toggle switch | '' */
+  name: PropTypes.string,
+  /** @prop Callback function invoked when state is changed | null */
   onChange: PropTypes.func,
+  /** @prop Sets the value of the toggle switch | '' */
+  value: PropTypes.string,
 };
 
 ToggleSwitch.defaultProps = {
-  disabled: false,
   checked: false,
-  name: '',
-  label: '',
-  value: '',
   className: '',
-  inputRef: null,
+  disabled: false,
+  label: '',
+  name: '',
   onChange: null,
+  value: '',
 };
+
+ToggleSwitch.displayName = 'ToggleSwitch';
 
 export default ToggleSwitch;
 

--- a/src/lib/Tooltip/index.js
+++ b/src/lib/Tooltip/index.js
@@ -9,7 +9,6 @@ import { Popover } from '@collab-ui/react';
  */
 
 class Tooltip extends React.Component {
-  static displayName = 'Tooltip';
 
   render () {
     const {
@@ -50,6 +49,19 @@ class Tooltip extends React.Component {
   }
 }
 
+Tooltip.propTypes = {
+  /** @prop Children nodes to render inside Tooltip component | null */
+  children: PropTypes.node,
+  /** @prop Optional CSS class string | '' */
+  className: PropTypes.string,
+  /** @prop Tooltip text | '' */
+  tooltip: PropTypes.string,
+  /** @prop Set the action which triggers the Tooltip | 'MouseEnter' */
+  tooltipTrigger: PropTypes.oneOf(['MouseEnter', 'Click', 'Focus']),
+  /** @prop Set the Tooltip width | null */
+  width: PropTypes.number
+};
+
 Tooltip.defaultProps = {
   children: null,
   className: '',
@@ -58,28 +70,7 @@ Tooltip.defaultProps = {
   width: null
 };
 
-Tooltip.propTypes = {
-  /**
-   * children of class
-   */
-  children: PropTypes.node,
-  /**
-   * css class names
-   */
-  className: PropTypes.string,
-  /**
-   * Tooltip Message
-   */
-  tooltip: PropTypes.string,
-  /**
-   * Event that will trigger tooltip appearance
-   */
-  tooltipTrigger: PropTypes.oneOf(['MouseEnter', 'Click', 'Focus']),
-  /**
-   * width of tooltip content
-   */
-  width: PropTypes.number
-};
+Tooltip.displayName = 'Tooltip';
 
 export default Tooltip;
 

--- a/src/lib/Topbar/index.js
+++ b/src/lib/Topbar/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 class Topbar extends React.Component {
-  static displayName = 'Topbar';
 
   state = {
     isMobileOpen: false,
@@ -101,32 +100,25 @@ class Topbar extends React.Component {
   }
 }
 
-Topbar.childContextTypes = {
-  focus: PropTypes.number,
-  activeIndex: PropTypes.number,
-  onActivate: PropTypes.func,
-  onFocus: PropTypes.func,
-};
-
 Topbar.propTypes = {
-  /** App Url/Link (String) */
+  /** @prop App Url/Link | null */
   anchor: PropTypes.string,
-  /** Custom Node to wrap (Element) */
+  /** @prop Custom Node to wrap | null */
   brandAnchorElement: PropTypes.element,
-  /** Title Text (String or Template) */
-  title: PropTypes.string,
-  /** Icon Class (String or Template) */
-  icon: PropTypes.string,
-  /** Image Source URL (String or Template) */
-  image: PropTypes.node,
-  /** Header Color (String) */
-  color: PropTypes.string,
-  /** Top-bar fixed to top (Boolean) */
-  fixed: PropTypes.bool,
-  /** children prop */
+  /** @prop Children nodes to render inside of Topbar | null */
   children: PropTypes.node,
-  /** HTML Class for Top Bar */
+  /** @prop Optional CSS class string | '' */
   className: PropTypes.string,
+  /** @prop Topbar header color | '' */
+  color: PropTypes.string,
+  /** @prop Determines if Topbar is fixed to top | false */
+  fixed: PropTypes.bool,
+  /** @prop Icon class name | 'icon-cisco-logo' */
+  icon: PropTypes.string,
+  /** @prop Image source URL | null */
+  image: PropTypes.node,
+  /** @prop Topbar title text | '' */
+  title: PropTypes.string,
 };
 
 Topbar.defaultProps = {
@@ -140,5 +132,14 @@ Topbar.defaultProps = {
   image: null,
   title: '',
 };
+
+Topbar.childContextTypes = {
+  focus: PropTypes.number,
+  activeIndex: PropTypes.number,
+  onActivate: PropTypes.func,
+  onFocus: PropTypes.func,
+};
+
+Topbar.displayName = 'Topbar';
 
 export default Topbar;

--- a/src/lib/TopbarMobile/index.js
+++ b/src/lib/TopbarMobile/index.js
@@ -85,13 +85,13 @@ class TopbarMobile extends React.Component {
 }
 
 TopbarMobile.propTypes = {
-  /** Brand Node */
+  /** @prop Brand Node | null */
   brandNode: PropTypes.node,
-  /** Children components */
+  /** @prop Children node to render inside of TopbarMobile | null */
   children: PropTypes.node,
-  /** Aria Label for close Button */
+  /** @prop Aria Label for close Button | 'Close Menu' */
   closeMenuAriaLabel: PropTypes.string,
-  /** Aria Label for open Button */
+  /** @prop Aria Label for open Button | 'Open Menu */
   openMenuAriaLabel: PropTypes.string,
 };
 
@@ -101,5 +101,7 @@ TopbarMobile.defaultProps = {
   closeMenuAriaLabel: 'Close Menu',
   openMenuAriaLabel: 'Open Menu',
 };
+
+TopbarMobile.displayName = 'TopbarMobile';
 
 export default TopbarMobile;

--- a/src/lib/TopbarNav/index.js
+++ b/src/lib/TopbarNav/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { List } from '@collab-ui/react';
 
 class TopbarNav extends React.Component {
-  static displayName = 'TopbarNav';
 
   render() {
     const { children, className } = this.props;
@@ -20,20 +19,18 @@ class TopbarNav extends React.Component {
   }
 }
 
+TopbarNav.propTypes = {
+  /** @prop Children node to render inside of TopbarNav | null */
+  children: PropTypes.node,
+  /** @prop Optional CSS class string | '' */
+  className: PropTypes.string,
+};
+
 TopbarNav.defaultProps = {
   children: null,
   className: '',
 };
 
-TopbarNav.propTypes = {
-  /**
-   * Children components
-   */
-  children: PropTypes.node,
-  /**
-   * CSS classnames
-   */
-  className: PropTypes.string,
-};
+TopbarNav.displayName = 'TopbarNav';
 
 export default TopbarNav;

--- a/src/lib/TopbarRight/index.js
+++ b/src/lib/TopbarRight/index.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
  * @param props
  */
 class TopbarRight extends React.PureComponent {
-  static displayName = 'TopbarRight';
 
   render() {
     const { className, children } = this.props;
@@ -22,20 +21,18 @@ class TopbarRight extends React.PureComponent {
   }
 }
 
+TopbarRight.propTypes = {
+  /** @prop Children node to render inside of TopbarRight | null */
+  children: PropTypes.node,
+  /** @prop Optional CSS class string | '' */
+  className: PropTypes.string,
+};
+
 TopbarRight.defaultProps = {
   children: null,
   className: '',
 };
 
-TopbarRight.propTypes = {
-  /**
-   * Children components
-   */
-  children: PropTypes.node,
-  /**
-   * CSS classnames
-   */
-  className: PropTypes.string,
-};
+TopbarRight.displayName = 'TopbarRight';
 
 export default TopbarRight;


### PR DESCRIPTION
Adding comments for each propType in each React Component for documentation purposes. Ex:
`/** @prop Children nodes to render inside Accordion | null */`

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-react/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [x] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
many propTypes are not at all defined in a comment, or are defined poorly or incorrectly.

**What is the new behavior?**
There is consistency across all React Components with how each propType is defined in a comment. If it is not required and has a default prop definition, part of the comment states the default value after a pipe. 

After this is passed through the prop-parser, it should generate a clear overview document of all defined props.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
