### PR TITLE
feat(Popover): add initial open trigger

### DIFF
--- a/src/lib/Avatar/index.spec.js
+++ b/src/lib/Avatar/index.spec.js
@@ -203,12 +203,26 @@ describe('tests for <Avatar />', () => {
   });
 
   it('should apply clickable class when onClick prop is defined', () => {
-    let container = mount(<Avatar src="test.png" title="Test Group" onClick={()=>{}} />);
+    let container = mount(
+      <Avatar
+        src="test.png"
+        title="Test Group"
+        onClick={()=>{}}
+        ariaLabel='Test onClick'
+      />
+    );
+
     expect(container.find('.cui-avatar--clickable').length).toEqual(1);
   });
 
   it('should not apply clickable class when onClick prop is undefined', () => {
-    let container = mount(<Avatar src="test.png" title="Test Group" />);
+    let container = mount(
+      <Avatar
+        src="test.png"
+        title="Test Group"
+      />
+    );
+
     expect(container.find('.cui-avatar--clickable').length).toEqual(0);
   });
 

--- a/src/lib/Popover/__snapshots__/index.spec.js.snap
+++ b/src/lib/Popover/__snapshots__/index.spec.js.snap
@@ -19,6 +19,7 @@ ShallowWrapper {
     popoverTrigger="MouseEnter"
     showArrow={true}
     showDelay={0}
+    startOpen={false}
   >
     <button>
       Hello

--- a/src/lib/Popover/index.js
+++ b/src/lib/Popover/index.js
@@ -17,7 +17,7 @@ class Popover extends React.Component {
   };
 
   componentDidMount() {
-    this.props.popoverTrigger === 'Open' &&
+    this.props.startOpen &&
     this.delayedShow();
   }
 
@@ -172,6 +172,7 @@ class Popover extends React.Component {
       'hoverDelay',
       'onClose',
       'showDelay',
+      'startOpen',
     ]);
 
     const getTriggers = () => {
@@ -281,6 +282,8 @@ Popover.propTypes = {
   showArrow: PropTypes.bool,
   /** @prop The show delay for popover on hover, click, focus | 0 */
   showDelay: PropTypes.number,
+  /** @prop Should Popover start open | false */
+  startOpen: PropTypes.bool,
 };
 
 Popover.defaultProps = {
@@ -294,6 +297,7 @@ Popover.defaultProps = {
   popoverTrigger: 'MouseEnter',
   showArrow: true,
   showDelay: 0,
+  startOpen: false,
 };
 
 Popover.displayName = 'Popover';
@@ -484,15 +488,17 @@ export default Popover;
           <h3>
             Props
             <p><code className="small">direction=(bottom-center)</code></p>
-            <p><code className="small">popoverTrigger=(Open)</code></p>
+            <p><code className="small">popoverTrigger=('None')</code></p>
             <p><code className="small">doesAnchorToggle(false)</code></p>
             <p><code className="small">allowClickAway(false)</code></p>
+            <p><code className="small">startOpen(true)</code></p>
           </h3>
           <Popover
             content={'Always Open'}
             direction={'bottom-center'}
             doesAnchorToggle={false}
-            popoverTrigger={'Open'}
+            popoverTrigger={'None'}
+            startOpen
             allowClickAway={false}
           >
             <Button

--- a/src/lib/Popover/index.js
+++ b/src/lib/Popover/index.js
@@ -207,7 +207,7 @@ class Popover extends React.Component {
 
           break;
 
-        case 'Open':
+        case 'None':
           triggerProps.onClick = null;
           triggerProps.onFocus = null;
           triggerProps.onBlur = null;

--- a/src/lib/Popover/index.js
+++ b/src/lib/Popover/index.js
@@ -16,6 +16,11 @@ class Popover extends React.Component {
     isHovering: false
   };
 
+  componentDidMount() {
+    this.props.popoverTrigger === 'Open' &&
+    this.delayedShow();
+  }
+
   componentWillUnmount() {
     this.hideTimerId && clearTimeout(this.hideTimerId);
     this.showTimerId && clearTimeout(this.showTimerId);
@@ -43,7 +48,7 @@ class Popover extends React.Component {
       );
     }, popoverHideTime);
 
-    e.stopPropagation();
+    e && e.stopPropagation();
   };
 
   delayedShow = e => {
@@ -65,7 +70,7 @@ class Popover extends React.Component {
       );
     }, popoverShowTime);
 
-    e.stopPropagation();
+    e && e.stopPropagation();
   };
 
   handleClose = e => {
@@ -196,6 +201,15 @@ class Popover extends React.Component {
         case 'Focus':
           triggerProps.onFocus = this.handleFocus;
           triggerProps.onBlur = this.handleBlur;
+          triggerProps.onMouseEnter = null;
+          triggerProps.onMouseLeave = null;
+
+          break;
+
+        case 'Open':
+          triggerProps.onClick = null;
+          triggerProps.onFocus = null;
+          triggerProps.onBlur = null;
           triggerProps.onMouseEnter = null;
           triggerProps.onMouseLeave = null;
 
@@ -436,7 +450,6 @@ export default Popover;
           <Popover
             content={content}
             direction={'bottom-center'}
-            popoverTrigger={'Click'}
           >
             <Button
               children='Click'
@@ -462,6 +475,29 @@ export default Popover;
             <Button
               children='Click No Toggle'
               ariaLabel='Click'
+            />
+          </Popover>
+
+        </div>
+        <div className="docs-example docs-example--spacing">
+
+          <h3>
+            Props
+            <p><code className="small">direction=(bottom-center)</code></p>
+            <p><code className="small">popoverTrigger=(Open)</code></p>
+            <p><code className="small">doesAnchorToggle(false)</code></p>
+            <p><code className="small">allowClickAway(false)</code></p>
+          </h3>
+          <Popover
+            content={'Always Open'}
+            direction={'bottom-center'}
+            doesAnchorToggle={false}
+            popoverTrigger={'Open'}
+            allowClickAway={false}
+          >
+            <Button
+              children='Always Open'
+              ariaLabel='Always Open'
             />
           </Popover>
 

--- a/src/lib/Popover/index.spec.js
+++ b/src/lib/Popover/index.spec.js
@@ -220,6 +220,25 @@ describe('tests for <Popover />', () => {
     expect(container.find('.popover-content').length).toEqual(0);
   });
 
+  it('should render one Popover with popoverTrigger(Open)', () => {
+    const content = (
+      <span className='popover-content' key='1'>
+        Hello how are you doing
+      </span>
+    );
+    const container = mount(
+      <Popover content={content} popoverTrigger={'Open'}>
+        <button tabIndex='0' className='anchor'>
+          Hello
+        </button>
+      </Popover>
+    );
+
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(1);
+  });
+
   it('when show and hide with showDelay/hideDelay', () => {
     const content = (
       <span className='popover-content' key='1'>

--- a/src/lib/Popover/index.spec.js
+++ b/src/lib/Popover/index.spec.js
@@ -220,14 +220,14 @@ describe('tests for <Popover />', () => {
     expect(container.find('.popover-content').length).toEqual(0);
   });
 
-  it('should render one Popover with popoverTrigger(Open)', () => {
+  it('should start open and close Popover', () => {
     const content = (
       <span className='popover-content' key='1'>
         Hello how are you doing
       </span>
     );
     const container = mount(
-      <Popover content={content} popoverTrigger={'Open'}>
+      <Popover content={content} popoverTrigger={'MouseEnter'} startOpen>
         <button tabIndex='0' className='anchor'>
           Hello
         </button>
@@ -237,6 +237,66 @@ describe('tests for <Popover />', () => {
     jest.runAllTimers();
     container.update();
     expect(container.find('.popover-content').length).toEqual(1);
+
+    container.find('.anchor').simulate('mouseleave');
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(0);
+  });
+
+  it('should render one Popover and not have Triggers', () => {
+    const content = (
+      <span className='popover-content' key='1'>
+        Hello how are you doing
+      </span>
+    );
+
+    const container = mount(
+      <Popover content={content} popoverTrigger={'None'} startOpen>
+        <button tabIndex='0' className='anchor'>
+          Hello
+        </button>
+      </Popover>
+    );
+
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(1);
+
+    container.find('.anchor').simulate('mouseleave');
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(1);
+  });
+
+  it('should not render Popover with popoverTrigger(None)', () => {
+    const content = (
+      <span className='popover-content' key='1'>
+        Hello how are you doing
+      </span>
+    );
+    const container = mount(
+      <Popover content={content} popoverTrigger={'None'}>
+        <button tabIndex='0' className='anchor'>
+          Hello
+        </button>
+      </Popover>
+    );
+
+    container.find('.anchor').simulate('focus');
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(0);
+
+    container.find('.anchor').simulate('mouseenter');
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(0);
+
+    container.find('button').simulate('click');
+    jest.runAllTimers();
+    container.update();
+    expect(container.find('.popover-content').length).toEqual(0);
   });
 
   it('when show and hide with showDelay/hideDelay', () => {

--- a/src/lib/Tooltip/__snapshots__/index.spec.js.snap
+++ b/src/lib/Tooltip/__snapshots__/index.spec.js.snap
@@ -43,6 +43,7 @@ ShallowWrapper {
       "popoverTrigger": "MouseEnter",
       "showArrow": true,
       "showDelay": 0,
+      "startOpen": false,
     },
     "ref": null,
     "rendered": Object {
@@ -82,6 +83,7 @@ ShallowWrapper {
         "popoverTrigger": "MouseEnter",
         "showArrow": true,
         "showDelay": 0,
+        "startOpen": false,
       },
       "ref": null,
       "rendered": Object {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-react/blob/master/CONTRIBUTING.md#commit-message-format
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)

Popover only opens with defined event triggers.

**What is the new behavior?**

Popover can be open by default without a trigger using startOpen prop.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

The popoverTrigger prop has a new option of 'None' to remove all triggers.