### PR TITLE
fix(Button): componentDidUpdate - check previous focus before setting…

### DIFF
--- a/src/lib/Button/index.js
+++ b/src/lib/Button/index.js
@@ -25,12 +25,17 @@ class Button extends React.Component {
     /* eslint-enable no-console */
   }
 
+  componentWillUpdate() {
+    this.prevContext = this.context;
+  }
+
   componentDidUpdate () {
     const { focusIndex } = this.context;
     const { index } = this.props;
 
     typeof index === 'number'
     && index === focusIndex
+    && focusIndex !== this.prevContext.focusIndex
     && this.refs.button.focus();
   }
 


### PR DESCRIPTION
… button focus

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/collab-ui/collab-ui-react/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


**What is the current behavior?** (You can also link to an open issue here)
When a Button within a ButtonGroup updates, it automatically re-focuses, even if the focusIndex didn't change.

**What is the new behavior?**
A Button within a ButtonGroup will only set focus if the focusIndex changed. This PR essentially restores the behavior that was erroneously removed here: https://github.com/collab-ui/collab-ui-react/pull/190/files#diff-76c973e8add5d2f298465ea784a046f3L33 in a React 16 compliant way.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
This method is **UNSAFE** and will be deprecated in React 17. https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate